### PR TITLE
[FEATURE] Require fulfillment to reject transfer

### DIFF
--- a/migrations/20150820161813-init.js
+++ b/migrations/20150820161813-init.js
@@ -29,6 +29,8 @@ module.exports = {
       state: Sequelize.ENUM('proposed', 'pre_prepared', 'prepared', 'pre_executed', 'executed', 'rejected'),
       execution_condition: Sequelize.TEXT,
       execution_condition_fulfillment: Sequelize.TEXT,
+      cancellation_condition: Sequelize.TEXT,
+      cancellation_condition_fulfillment: Sequelize.TEXT,
       expires_at: Sequelize.DATE,
       timeline: Sequelize.TEXT,
       proposed_at: Sequelize.DATE,

--- a/src/controllers/transfers.js
+++ b/src/controllers/transfers.js
@@ -113,13 +113,8 @@ function updateTransferObject (originalTransfer, transfer) {
   // Ignore null properties
   updatedTransferData = _.omit(updatedTransferData, _.isNull)
 
-  // Clients can change the state to "rejected".
-  if (transfer.state === 'rejected' && !originalTransfer.isFinalized()) {
-    transfer.state = updatedTransferData.state = 'pre_rejected'
-  } else {
-    transfer.state = updatedTransferData.state
-  }
   // Ignore internally managed properties
+  transfer.state = updatedTransferData.state
   transfer.created_at = updatedTransferData.created_at
   transfer.updated_at = updatedTransferData.updated_at
   transfer.proposed_at = updatedTransferData.proposed_at
@@ -253,7 +248,7 @@ function * processStateTransitions (tr, transfer) {
     transferExpiryMonitor.unwatch(transfer.id)
   }
 
-  if (transfer.state === 'pre_rejected') {
+  if (transfer.cancellation_condition_fulfillment) {
     if (!transfer.hasValidFulfillment('cancellation')) {
       throw new UnmetConditionError('ConditionFulfillment failed')
     }

--- a/src/controllers/transfers.js
+++ b/src/controllers/transfers.js
@@ -248,11 +248,14 @@ function * processStateTransitions (tr, transfer) {
     transferExpiryMonitor.unwatch(transfer.id)
   }
 
-  if (transfer.cancellation_condition_fulfillment) {
+  let canRejectState = transfer.state === 'proposed' || transfer.state === 'prepared'
+  if (canRejectState && transfer.cancellation_condition_fulfillment) {
     if (!transfer.hasValidFulfillment('cancellation')) {
       throw new UnmetConditionError('ConditionFulfillment failed')
     }
-    yield accountBalances.revertDebits()
+    if (transfer.state === 'prepared') {
+      yield accountBalances.revertDebits()
+    }
     updateState(transfer, 'rejected')
     transferExpiryMonitor.unwatch(transfer.id)
   }

--- a/src/lib/transferExpiryMonitor.js
+++ b/src/lib/transferExpiryMonitor.js
@@ -33,9 +33,7 @@ TransferExpiryMonitor.prototype.expireTransfer = function * (transferId) {
       return
     }
 
-    if (transfer.state !== 'executed' &&
-      transfer.state !== 'rejected' &&
-      transfer.state !== 'failed') {
+    if (!transfer.isFinalized()) {
       updateState(transfer, 'rejected')
       yield transfer.save({ transaction })
 

--- a/src/models/transfer.js
+++ b/src/models/transfer.js
@@ -4,6 +4,7 @@ const _ = require('lodash')
 
 const Model = require('five-bells-shared').Model
 const PersistentModelMixin = require('five-bells-shared').PersistentModelMixin
+const Condition = require('five-bells-condition').Condition
 const validator = require('../services/validator')
 const uri = require('../services/uriManager')
 
@@ -87,6 +88,26 @@ class Transfer extends Model {
   isFinalized () {
     return _.includes(FINAL_STATES, this.state)
   }
+
+  _condition (action) {
+    return action === 'execution' ? this.execution_condition : this.cancellation_condition
+  }
+  _fulfillment (action) {
+    return action === 'execution' ? this.execution_condition_fulfillment : this.cancellation_condition_fulfillment
+  }
+
+  hasFulfillment (action) {
+    if (!this._condition(action)) return true
+    return !!this._fulfillment(action)
+  }
+
+  hasValidFulfillment (action) {
+    if (!this._condition(action)) return true
+    if (!this._fulfillment(action)) return false
+    return Condition.testFulfillment(
+      this._condition(action),
+      this._fulfillment(action))
+  }
 }
 
 Transfer.validateExternal = validator.create('Transfer')
@@ -103,6 +124,8 @@ PersistentModelMixin(Transfer, sequelize, {
   state: Sequelize.ENUM('proposed', 'pre_prepared', 'prepared', 'pre_executed', 'executed', 'rejected'),
   execution_condition: JsonField(sequelize, 'Transfer', 'execution_condition'),
   execution_condition_fulfillment: JsonField(sequelize, 'Transfer', 'execution_condition_fulfillment'),
+  cancellation_condition: JsonField(sequelize, 'Transfer', 'cancellation_condition'),
+  cancellation_condition_fulfillment: JsonField(sequelize, 'Transfer', 'cancellation_condition_fulfillment'),
   expires_at: Sequelize.DATE,
   proposed_at: Sequelize.DATE,
   pre_prepared_at: Sequelize.DATE,

--- a/test/putTransferSpec.js
+++ b/test/putTransferSpec.js
@@ -595,19 +595,6 @@ describe('PUT /transfers/:id', function () {
         .expect(201)
         .end()
 
-      // Missing fulfillment
-      transfer.state = 'rejected'
-      yield this.request()
-        .put(transfer.id)
-        .auth('alice', 'alice')
-        .send(transfer)
-        .expect(422)
-        .expect({
-          id: 'UnmetConditionError',
-          message: 'ConditionFulfillment failed'
-        })
-        .end()
-
       // Invalid fulfillment
       transfer.cancellation_condition_fulfillment = {
         'type': 'ed25519-sha512',


### PR DESCRIPTION
Allow clients to reject transfers, and require the `execution_condition_fulfillment` to do so.

Requires https://github.com/interledger/five-bells-shared/pull/37