### PR TITLE
[TASK] Assorted admin/hold fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ With the following configuration options set as environment variables:
 * `LEDGER_HOSTNAME` (default: *[your hostname]*) Publicly visible hostname. This is important for things like generating globally unique IDs. Make sure this is a hostname that all your clients will be able to see. The default should be fine for local testing.
 * `LEDGER_PUBLIC_PORT` (default: `$PORT`) Publicly visible port. You can set this if your public port differs from the listening port, e.g. because the ledger is running behind a proxy.
 * `LEDGER_PUBLIC_HTTPS` (default: `''`) Whether or not the publicly visible instance of Five Bells Ledger is using HTTPS.
+* `LEDGER_ADMIN_USER` (default: `'admin'`) The admin account's username (an admin user can create/modify accounts).
+* `LEDGER_ADMIN_PASS` (default: none) The admin account's password.
 
 
 ## Running with Docker (Alternative Method)

--- a/app.js
+++ b/app.js
@@ -91,15 +91,26 @@ if (!module.parent) {
       }
     }
 
+    const holdAccount = yield models.Account.findByName('hold')
+    if (!holdAccount) {
+      yield models.Account.create({name: 'hold', balance: '0'})
+    }
+
     if (config.default_admin) {
       let admin = config.default_admin
-      yield models.Account.create({
-        id: admin.user,
-        name: admin.user,
-        balance: '0',
-        password: admin.pass,
-        is_admin: true
-      })
+      let admin_account = yield models.Account.findByName(admin.user)
+      // Update the password if the account already exists.
+      if (admin_account) {
+        admin_account.password = admin.pass
+        yield admin_account.save()
+      } else {
+        yield models.Account.create({
+          name: admin.user,
+          balance: '0',
+          password: admin.pass,
+          is_admin: true
+        })
+      }
     }
 
     app.listen(config.server.port)

--- a/src/lib/accountBalances.js
+++ b/src/lib/accountBalances.js
@@ -98,12 +98,10 @@ AccountBalances.prototype._saveAccount = function * (account, group) {
 
 AccountBalances.prototype._holdAccount = function * () {
   const holdAccount = yield Account.findByName('hold', {transaction: this.transaction})
-  return holdAccount ||
-    (yield Account.create({
-      id: 'hold',
-      name: 'hold',
-      balance: '0'
-    }, {transaction: this.transaction}))
+  if (!holdAccount) {
+    throw new Error('Missing "hold" account')
+  }
+  return holdAccount
 }
 
 module.exports = function * (transaction, transfer) {

--- a/src/models/account.js
+++ b/src/models/account.js
@@ -49,11 +49,17 @@ class Account extends Model {
   }
 
   static findById (id, options) {
-    return Account.findOne({where: {primary: id}}, options)
+    return Account.findOne({
+      where: {primary: id},
+      transaction: options && options.transaction
+    })
   }
 
   static findByName (name, options) {
-    return Account.findOne({where: {name: name}}, options)
+    return Account.findOne({
+      where: {name: name},
+      transaction: options && options.transaction
+    })
   }
 
   createEntry (values, options) {

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -16,9 +16,11 @@ if (process.env.NODE_ENV === 'unit') {
   config.updateDerivativeServerConfig()
 }
 
-if (config.getEnv('ADMIN_USER')) {
+let admin_user = config.getEnv('ADMIN_USER') || 'admin'
+let admin_pass = config.getEnv('ADMIN_PASS')
+if (admin_pass) {
   config.default_admin = {
-    user: config.getEnv('ADMIN_USER'),
-    pass: config.getEnv('ADMIN_PASS')
+    user: admin_user,
+    pass: admin_pass
   }
 }

--- a/test/accountSpec.js
+++ b/test/accountSpec.js
@@ -21,26 +21,33 @@ describe('Accounts', function () {
     // Define example data
     this.exampleAccounts = _.cloneDeep(require('./data/accounts'))
     this.adminAccount = this.exampleAccounts.admin
+    this.holdAccount = this.exampleAccounts.hold
     this.existingAccount = this.exampleAccounts.alice
 
     // Reset database
     yield dbHelper.reset()
 
     // Store some example data
-    yield dbHelper.addAccounts([this.adminAccount, this.existingAccount])
+    yield dbHelper.addAccounts([
+      this.adminAccount,
+      this.holdAccount,
+      this.existingAccount
+    ])
   })
 
   describe('GET /accounts', function () {
     it('should return 200', function *() {
       const account1 = this.adminAccount
-      const account2 = this.existingAccount
+      const account2 = this.holdAccount
+      const account3 = this.existingAccount
       // Passwords are not returned
       delete account1.password
       delete account2.password
+      delete account3.password
       yield this.request()
         .get('/accounts')
         .expect(200)
-        .expect([account1, account2])
+        .expect([account1, account2, account3])
         .end()
     })
 

--- a/test/data/accounts.json
+++ b/test/data/accounts.json
@@ -34,5 +34,10 @@
     "id": "http://localhost/accounts/eve",
     "name": "eve",
     "balance": "50"
+  },
+  "hold": {
+    "id": "http://localhost/accounts/hold",
+    "name": "hold",
+    "balance": "0"
   }
 }


### PR DESCRIPTION
* Fixes #57 (docs), #58 (default admin username), #59 (auto-update admin password)
* Correctly use "hold" account transactions so that postgres behaves as expected.
* Move "hold" account creation to `app.js` (@justmoon if this should be in the migration instead, let me know).