### PR TITLE
Add ability to delete accounts

### DIFF
--- a/app.js
+++ b/app.js
@@ -57,6 +57,10 @@ router.put('/accounts/:id',
   filterAdmin,
   models.Account.createBodyParser(),
   accounts.putResource)
+router.delete('/accounts/:id',
+  passport.authenticate(['basic', 'http-signature'], { session: false }),
+  filterAdmin,
+  accounts.deleteResource)
 
 router.post('/subscriptions', models.Subscription.createBodyParser(), subscriptions.postResource)
 router.get('/subscriptions/:id', subscriptions.getResource)

--- a/src/controllers/accounts.js
+++ b/src/controllers/accounts.js
@@ -93,3 +93,37 @@ exports.putResource = function * putResource () {
   this.body = this.body.getDataExternal()
   this.status = existed ? 200 : 201
 }
+
+/**
+ * @api {delete} /accounts/:id Delete a user
+ * @apiName DeleteAccount
+ * @apiGroup Account
+ * @apiVersion 1.0.0
+ *
+ * @apiDescription Delete a user.
+ *
+ * @apiParam {String} id Account's unique identifier
+ *
+ * @apiUse InvalidUriParameterError
+ * @apiUse InvalidBodyError
+ *
+ * @return {void}
+ */
+exports.deleteResource = function * deleteResource () {
+  const self = this
+  let id = this.params.id
+  request.validateUriParameter('id', id, 'Identifier')
+  id = id.toLowerCase()
+
+  yield db.transaction(function * (transaction) {
+    const account = yield Account.findByName(id, { transaction })
+    if (account) {
+      self.body = account.getDataExternal()
+      yield account.destroy({ transaction })
+      log.debug('deleted account ID ' + id)
+      self.status = 200
+    } else {
+      self.status = 404
+    }
+  })
+}

--- a/test/accountSpec.js
+++ b/test/accountSpec.js
@@ -195,6 +195,61 @@ describe('Accounts', function () {
     })
   })
 
+  describe('DELETE /accounts/:uuid', function () {
+    it('should delete the accounts if it exists', function *() {
+      const account = this.existingAccount
+      delete account.password
+      yield this.request()
+        .delete(account.id)
+        .auth('admin', 'admin')
+        .expect(200)
+        .expect(account)
+        .end()
+
+      // Check balances
+      expect(yield Account.findByName('bob')).to.be.null
+    })
+
+    it('should return 404 if the account does not exist', function *() {
+      const account = this.exampleAccounts.bob
+      delete account.password
+      yield this.request()
+        .delete(account.id)
+        .auth('admin', 'admin')
+        .expect(404)
+        .end()
+
+      // Check balances
+      expect(yield Account.findByName('bob')).to.be.null
+    })
+
+    it('should return 403 if the user is not an admin', function *() {
+      const account = this.existingAccount
+      delete account.password
+      yield this.request()
+        .delete(account.id)
+        .auth('alice', 'alice')
+        .expect(403)
+        .end()
+
+      // Check balances
+      expect(yield Account.findByName('bob')).to.be.null
+    })
+
+    it('should return 403 if the user is not an admin and the account does not exist', function *() {
+      const account = this.exampleAccounts.bob
+      delete account.password
+      yield this.request()
+        .delete(account.id)
+        .auth('alice', 'alice')
+        .expect(403)
+        .end()
+
+      // Check balances
+      expect(yield Account.findByName('bob')).to.be.null
+    })
+  })
+
   describe('Account#findEntry', function () {
     it('returns an Entry', function *() {
       yield dbHelper.addAccounts([this.exampleAccounts.bob])


### PR DESCRIPTION
Adds a new endpoint `DELETE /accounts/:id` for deleting existing accounts. Only the administrator is allowed to delete an account.

*Not* ready to merge! The current implementation will not allow deleting accounts that have transfers associated with them (foreign key constraints). It seems unwise to allow the deletion of transfers - the ledger history should never be altered. So perhaps instead of deleting accounts, what we actually want is a way to disable accounts.

cc/ @MatthewPhinney 