### PR TITLE
Pr/160113101545

### DIFF
--- a/app.js
+++ b/app.js
@@ -60,7 +60,6 @@ router.put('/accounts/:id',
   models.Account.createBodyParser(),
   accounts.putResource)
 
-router.post('/subscriptions', models.Subscription.createBodyParser(), subscriptions.postResource)
 router.get('/subscriptions/:id',
   passport.authenticate(['basic', 'http-signature'], { session: false }),
   subscriptions.getResource)

--- a/app.js
+++ b/app.js
@@ -61,9 +61,16 @@ router.put('/accounts/:id',
   accounts.putResource)
 
 router.post('/subscriptions', models.Subscription.createBodyParser(), subscriptions.postResource)
-router.get('/subscriptions/:id', subscriptions.getResource)
-router.put('/subscriptions/:id', models.Subscription.createBodyParser(), subscriptions.putResource)
-router.delete('/subscriptions/:id', subscriptions.deleteResource)
+router.get('/subscriptions/:id',
+  passport.authenticate(['basic', 'http-signature'], { session: false }),
+  subscriptions.getResource)
+router.put('/subscriptions/:id',
+  passport.authenticate(['basic', 'http-signature'], { session: false }),
+  models.Subscription.createBodyParser(),
+  subscriptions.putResource)
+router.delete('/subscriptions/:id',
+  passport.authenticate(['basic', 'http-signature'], { session: false }),
+  subscriptions.deleteResource)
 
 app.use(router.middleware())
 app.use(router.routes())

--- a/src/controllers/_apidoc.js
+++ b/src/controllers/_apidoc.js
@@ -83,3 +83,16 @@
  *       "message": "Error description here."
  *     }
  */
+
+/**
+ * @apiDefine UnauthorizedError
+ *
+ * @apiError UnauthorizedError You do not have permissions to access this resource.
+ *
+ * @apiErrorExample UnauthorizedError
+ *     HTTP/1.1 403 Forbidden
+ *     {
+ *       "id": "UnauthorizedError",
+ *       "message": "Error description here."
+ *     }
+ */

--- a/src/controllers/subscriptions.js
+++ b/src/controllers/subscriptions.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const uuid = require('uuid4')
 const db = require('../services/db')
 const log = require('../services/log')('subscriptions')
 const uri = require('../services/uriManager')
@@ -23,6 +22,7 @@ const Subscription = require('../models/subscription').Subscription
  *
  * @apiUse NotFoundError
  * @apiUse InvalidUriParameterError
+ * @apiUse UnauthorizedError
  *
  * @returns {void}
  */
@@ -44,8 +44,8 @@ exports.getResource = function * fetch () {
 }
 
 /**
- * @api {post} /subscriptions Subscribe to an event
- * @apiName PostSubscription
+ * @api {put} /subscriptions Subscribe to an event
+ * @apiName PutSubscription
  * @apiGroup Subscription
  * @apiVersion 1.0.0
  *
@@ -58,26 +58,10 @@ exports.getResource = function * fetch () {
  *     }
  *
  * @apiUse InvalidBodyError
+ * @apiUse UnauthorizedError
  *
  * @returns {void}
  */
-exports.postResource = function * create () {
-  const subscription = this.body
-
-  // Generate a unique subscription ID outside of the transaction block
-  if (!subscription.id) {
-    subscription.id = uuid()
-  }
-  log.debug('preparing subscription ID ' + subscription.id)
-
-  // Validate and store subscription in database
-  yield * storeSubscription(subscription)
-
-  log.debug('subscription created')
-
-  this.body = subscription.getDataExternal()
-  this.status = 201
-}
 
 exports.putResource = function * update () {
   let id = this.params.id
@@ -128,6 +112,7 @@ exports.putResource = function * update () {
  *
  * @apiUse NotFoundError
  * @apiUse InvalidUriParameterError
+ * @apiUse UnauthorizedError
  *
  * @returns {void}
  */

--- a/src/controllers/subscriptions.js
+++ b/src/controllers/subscriptions.js
@@ -3,47 +3,11 @@
 const uuid = require('uuid4')
 const db = require('../services/db')
 const log = require('../services/log')('subscriptions')
+const uri = require('../services/uriManager')
 const request = require('five-bells-shared/utils/request')
 const NotFoundError = require('five-bells-shared/errors/not-found-error')
-const Account = require('../models/account').Account
+const UnauthorizedError = require('five-bells-shared/errors/unauthorized-error')
 const Subscription = require('../models/subscription').Subscription
-
-/**
- * Validate a subscription semantically.
- *
- * We use schemas to validate data syntactically, this method takes care of all
- * remaining validations.
- *
- * @param {Object} subscription Subscription
- * @param {Object} tr Database transaction
- * @returns {void}
- */
-function * validateSubscriptionSemantics (subscription, transaction) {
-  const owner = yield Account.findByName(subscription.owner, { transaction })
-
-  if (typeof owner === 'undefined') {
-    // TODO Add authentication and reenable this check
-    // throw new UnprocessableEntityError('Owner does not exist.')
-  }
-}
-
-/**
- * Store a subscription in the database.
- *
- * @param {Object} subscription Subscription
- * @returns {void}
- */
-function * storeSubscription (subscription) {
-  yield db.transaction(function *(transaction) {
-    // Check prerequisites
-    yield * validateSubscriptionSemantics(subscription, transaction)
-
-    // Store subscription in database
-    // TODO: Who to subscribe to should be defined by a separate `subject`
-    //       field.
-    yield Subscription.upsert(subscription, { transaction })
-  })
-}
 
 /**
  * @api {get} /subscriptions/:id Get RESThook subscription
@@ -68,11 +32,14 @@ exports.getResource = function * fetch () {
   id = id.toLowerCase()
   log.debug('fetching subscription ID ' + id)
 
+  const requestOwner = uri.make('account', this.req.user.name)
   const subscription = yield Subscription.findById(id)
-  if (subscription) {
-    this.body = subscription.getDataExternal()
-  } else {
+  if (!subscription) {
     throw new NotFoundError('Unknown subscription ID')
+  } else if (!(requestOwner === subscription.owner || this.req.user.is_admin)) {
+    throw new UnauthorizedError('You may only view subscriptions you own')
+  } else {
+    this.body = subscription.getDataExternal()
   }
 }
 
@@ -118,6 +85,11 @@ exports.putResource = function * update () {
   id = id.toLowerCase()
   const subscription = this.body
 
+  const requestOwner = uri.make('account', this.req.user.name)
+  if (requestOwner !== subscription.owner) {
+    throw new UnauthorizedError('You do not own this account')
+  }
+
   if (typeof subscription.id !== 'undefined') {
     request.assert.strictEqual(subscription.id, id,
       'Subscription ID must match the one in the URL')
@@ -128,12 +100,19 @@ exports.putResource = function * update () {
   log.debug('updating subscription ID ' + subscription.id)
   log.debug('subscribed ' + subscription.owner + ' at ' + subscription.target)
 
-  // Validate and store subscription in database
-  yield * storeSubscription(subscription)
+  // SQLite's implementation of upsert does not tell you whether it created the
+  // row or whether it already existed. Since we need to know to return the
+  // correct HTTP status code we unfortunately have to do this in two steps.
+  let existed
+  yield db.transaction(function * (transaction) {
+    existed = yield Subscription.findById(id, { transaction })
+    yield Subscription.upsert(subscription, { transaction })
+  })
 
   log.debug('update completed')
 
   this.body = subscription.getDataExternal()
+  this.status = existed ? 200 : 201
 }
 
 /**
@@ -153,6 +132,7 @@ exports.putResource = function * update () {
  * @returns {void}
  */
 exports.deleteResource = function * remove () {
+  const self = this
   let id = this.params.id
   request.validateUriParameter('id', id, 'Uuid')
   id = id.toLowerCase()
@@ -164,6 +144,10 @@ exports.deleteResource = function * remove () {
 
     if (!subscription) {
       throw new NotFoundError('Unknown subscription ID')
+    }
+    const requestOwner = uri.make('account', self.req.user.name)
+    if (!(requestOwner === subscription.owner || self.req.user.is_admin)) {
+      throw new UnauthorizedError('You don\'t have permission to delete this subscription')
     }
 
     subscription.destroy({ transaction })

--- a/test/subscriptionSpec.js
+++ b/test/subscriptionSpec.js
@@ -44,6 +44,7 @@ describe('Subscriptions', function () {
     it('should return 200', function *() {
       yield this.request()
         .get(this.existingSubscription.id)
+        .auth('bob', 'bob')
         .expect(200)
         .expect(this.existingSubscription)
         .end()
@@ -52,22 +53,41 @@ describe('Subscriptions', function () {
     it('should return 404 for a non-existent subscription', function *() {
       yield this.request()
         .get(this.exampleSubscription.id)
+        .auth('bob', 'bob')
         .expect(404)
         .end()
     })
+
+    it('should return 403 for a subscription the user doesn\t own', function *() {
+      yield this.request()
+        .get(this.existingSubscription.id)
+        .auth('alice', 'alice')
+        .expect(403)
+        .end()
+    })
+
+    it('should allow an admin to view any subscription', function *() {
+      yield this.request()
+      .get(this.existingSubscription.id)
+      .auth('admin', 'admin')
+      .expect(200)
+      .expect(this.existingSubscription)
+      .end()
+    })
   })
 
-  describe('POST /subscriptions', function () {
+  describe('PUT /subscriptions', function () {
     it('should return 201', function *() {
+      const id = uri.parse(this.exampleSubscription.id, 'subscription').id
       yield this.request()
-        .post('/subscriptions')
+        .put(this.exampleSubscription.id)
         .send(this.exampleSubscription)
+        .auth('alice', 'alice')
         .expect(201)
         .expect(this.exampleSubscription)
         .end()
 
       // Check that the subscription landed in the database
-      const id = uri.parse(this.exampleSubscription.id, 'subscription').id
       expect((yield Subscription.findById(id)).getDataExternal())
         .to.deep.equal(this.exampleSubscription)
     })
@@ -77,6 +97,7 @@ describe('Subscriptions', function () {
       yield this.request()
         .put(this.existingSubscription.id)
         .send(this.existingSubscription)
+        .auth('bob', 'bob')
         .expect(200)
         .expect(this.existingSubscription)
         .end()
@@ -85,6 +106,15 @@ describe('Subscriptions', function () {
       const id = uri.parse(this.existingSubscription.id, 'subscription').id
       expect((yield Subscription.findById(id)).getDataExternal())
         .to.deep.equal(this.existingSubscription)
+    })
+
+    it('should return 403 for an account the user does not own', function *() {
+      yield this.request()
+        .put(this.exampleSubscription.id)
+        .send(this.exampleSubscription)
+        .auth('bob', 'bob')
+        .expect(403)
+        .end()
     })
   //
   //   it('should return 409 if the transfer already exists', function *() {
@@ -158,8 +188,25 @@ describe('Subscriptions', function () {
     it('should return 204', function *() {
       yield this.request()
         .delete(this.existingSubscription.id)
+        .auth('bob', 'bob')
         .expect(204)
         .end()
+    })
+
+    it('should return 403 if the user tries to delete a subscription they don\'t own', function *() {
+      yield this.request()
+        .delete(this.existingSubscription.id)
+        .auth('alice', 'alice')
+        .expect(403)
+        .end()
+    })
+
+    it('should return 204 when an admin deletes a subscription', function *() {
+      yield this.request()
+      .delete(this.existingSubscription.id)
+      .auth('admin', 'admin')
+      .expect(204)
+      .end()
     })
   })
 


### PR DESCRIPTION
Preliminary auth for subscription endpoints. The logic is as follows:
**GET**: a user may only view a subscription for an account they own, unless they are an admin, in which case they can view any subscription. They will receive a 404 if the subscription doesn't exist and a 403 if they are not authorized.
**PUT**: a user may only create a subscription in which the "owner" matches the user.
**What restrictions are placed on the `target` account(s)?**
**DELETE**: a user may only delete a subscription if they are the owner. An admin may delete any subscription. *Should we allow this?*

Once the above questions are addressed, this will resolve #99.
