### PR TITLE
Subscription auth

### DIFF
--- a/src/controllers/_apidoc.js
+++ b/src/controllers/_apidoc.js
@@ -83,3 +83,16 @@
  *       "message": "Error description here."
  *     }
  */
+
+/**
+ * @apiDefine UnauthorizedError
+ *
+ * @apiError UnauthorizedError You do not have permissions to access this resource.
+ *
+ * @apiErrorExample UnauthorizedError
+ *     HTTP/1.1 403 Forbidden
+ *     {
+ *       "id": "UnauthorizedError",
+ *       "message": "Error description here."
+ *     }
+ */

--- a/src/controllers/subscriptions.js
+++ b/src/controllers/subscriptions.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const uuid = require('uuid4')
 const db = require('../services/db')
 const log = require('../services/log')('subscriptions')
 const uri = require('../services/uriManager')
@@ -52,6 +51,7 @@ function * storeSubscription (subscription) {
  *
  * @apiUse NotFoundError
  * @apiUse InvalidUriParameterError
+ * @apiUse UnauthorizedError
  *
  * @returns {void}
  */
@@ -73,8 +73,8 @@ exports.getResource = function * fetch () {
 }
 
 /**
- * @api {post} /subscriptions Subscribe to an event
- * @apiName PostSubscription
+ * @api {put} /subscriptions Subscribe to an event
+ * @apiName PutSubscription
  * @apiGroup Subscription
  * @apiVersion 1.0.0
  *
@@ -87,26 +87,10 @@ exports.getResource = function * fetch () {
  *     }
  *
  * @apiUse InvalidBodyError
+ * @apiUse UnauthorizedError
  *
  * @returns {void}
  */
-exports.postResource = function * create () {
-  const subscription = this.body
-
-  // Generate a unique subscription ID outside of the transaction block
-  if (!subscription.id) {
-    subscription.id = uuid()
-  }
-  log.debug('preparing subscription ID ' + subscription.id)
-
-  // Validate and store subscription in database
-  yield * storeSubscription(subscription)
-
-  log.debug('subscription created')
-
-  this.body = subscription.getDataExternal()
-  this.status = 201
-}
 
 exports.putResource = function * update () {
   let id = this.params.id
@@ -154,6 +138,7 @@ exports.putResource = function * update () {
  *
  * @apiUse NotFoundError
  * @apiUse InvalidUriParameterError
+ * @apiUse UnauthorizedError
  *
  * @returns {void}
  */

--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -94,10 +94,16 @@ class App {
       models.Account.createBodyParser(),
       accounts.putResource)
 
-    router.post('/subscriptions', models.Subscription.createBodyParser(), subscriptions.postResource)
-    router.get('/subscriptions/:id', subscriptions.getResource)
-    router.put('/subscriptions/:id', models.Subscription.createBodyParser(), subscriptions.putResource)
-    router.delete('/subscriptions/:id', subscriptions.deleteResource)
+    router.get('/subscriptions/:id',
+      passport.authenticate(['basic', 'http-signature'], { session: false }),
+      subscriptions.getResource)
+    router.put('/subscriptions/:id',
+      passport.authenticate(['basic', 'http-signature'], { session: false }),
+      models.Subscription.createBodyParser(),
+      subscriptions.putResource)
+    router.delete('/subscriptions/:id',
+      passport.authenticate(['basic', 'http-signature'], { session: false }),
+      subscriptions.deleteResource)
     return router
   }
 }

--- a/test/subscriptionSpec.js
+++ b/test/subscriptionSpec.js
@@ -125,6 +125,27 @@ describe('Subscriptions', function () {
         .expect(403)
         .end()
     })
+
+    it('should return 403 if the user doesn\'t own the subject account', function *() {
+      this.exampleSubscription.subject = this.existingSubscription.subject
+      yield this.request()
+        .put(this.exampleSubscription.id)
+        .send(this.exampleSubscription)
+        .auth('alice', 'alice')
+        .expect(403)
+        .end()
+    })
+
+    it('should return 201 when an admin subscribes to any subject account', function *() {
+      this.exampleSubscription.owner = 'http://localhost/accounts/admin'
+      /* The subject is Alices's account */
+      yield this.request()
+        .put(this.exampleSubscription.id)
+        .send(this.exampleSubscription)
+        .auth('admin', 'admin')
+        .expect(201)
+        .end()
+    })
   //
   //   it('should return 409 if the transfer already exists', function *() {
   //     yield this.request()


### PR DESCRIPTION
Preliminary auth for subscription endpoints. The logic is as follows:
**GET**: a user may only view a subscription for an account they own, unless they are an admin, in which case they can view any subscription. They will receive a 404 if the subscription doesn't exist and a 403 if they are not authorized.
**PUT**: a user may only create a subscription in which the "owner" matches the user.
**What restrictions are placed on the `target` account(s)?**
**DELETE**: a user may only delete a subscription if they are the owner. An admin may delete any subscription. *Should we allow this?*

Once the above questions are addressed, this will resolve #99.