### PR TITLE
[FEATURE] /state: type=sha256, pretend_state

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "five-bells-condition": "~2.0.0",
     "five-bells-shared": "~8.8.0",
+    "canonical-json": "0.0.4",
     "co": "^4.1.0",
     "co-defer": "^1.0.0",
     "co-emitter": "^0.2.3",


### PR DESCRIPTION
Fixes #89

This implementation uses `ed25519(sha512(transfer_id), secret_key)` as the hash's secret, but that's flexible.