### PR TITLE
[FEATURE] /state: type=sha256, condition_state

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "five-bells-condition": "~2.0.0",
     "five-bells-shared": "~8.9.0",
+    "canonical-json": "0.0.4",
     "co": "^4.1.0",
     "co-defer": "^1.0.0",
     "co-emitter": "^0.2.3",


### PR DESCRIPTION
Fixes #89 (though I call the parameter `condition_state` instead of `pretend_state` to make it more clear what the intended purpose is).

When `condition_state` is provided, the `/state` endpoint will return `condition_state` and `condition_digest`, in addition to the regular `digest` &c.