### PR TITLE
Refactor depends on five-bells-shared@8.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "five-bells-condition": "~2.0.0",
-    "five-bells-shared": "~8.8.0",
+    "five-bells-shared": "~8.9.0",
     "co": "^4.1.0",
     "co-defer": "^1.0.0",
     "co-emitter": "^0.2.3",


### PR DESCRIPTION
Recently merged refactor depends on `five-bells-shared@8.9.0`, otherwise throws:

```
2016-01-23T02:06:00.613Z app CRIT TypeError: this.db.init is not a function
    at App._start (/var/app/src/lib/app.js:58:19)
    at next (native)
    at onFulfilled (/var/app/node_modules/co/index.js:65:19)
    at tryCatcher (/var/app/node_modules/bluebird/js/release/util.js:11:23)
    at Promise._settlePromiseFromHandler (/var/app/node_modules/bluebird/js/release/promise.js:488:31)
    at Promise._settlePromise (/var/app/node_modules/bluebird/js/release/promise.js:545:18)
    at Promise._settlePromise0 (/var/app/node_modules/bluebird/js/release/promise.js:590:10)
    at Promise._settlePromises (/var/app/node_modules/bluebird/js/release/promise.js:673:18)
    at Async._drainQueue (/var/app/node_modules/bluebird/js/release/async.js:125:16)
    at Async._drainQueues (/var/app/node_modules/bluebird/js/release/async.js:135:10)
    at Immediate.Async.drainQueues [as _onImmediate] (/var/app/node_modules/bluebird/js/release/async.js:16:14)
    at processImmediate [as _immediateCallback] (timers.js:383:17)
```