### PR TITLE
Initial implementation for client certificate authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ apidoc-out/
 coverage/
 *.cluster
 /npm-debug.log
+*.pem
+*.cnf
+*.pfx
+*.srl

--- a/migrations/20160127110439-account-fingerprint.js
+++ b/migrations/20160127110439-account-fingerprint.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {
+  up: function (queryInterface, Sequelize) {
+    queryInterface.addColumn('Accounts', 'fingerprint', Sequelize.STRING)
+  },
+
+  down: function (queryInterface, Sequelize) {
+    queryInterface.removeColumn('Accounts', 'fingerprint')
+  }
+};

--- a/src/models/db/account.js
+++ b/src/models/db/account.js
@@ -70,6 +70,13 @@ class Account extends Model {
     })
   }
 
+  static findByFingerprint (fingerprint, options) {
+    return Account.findOne({
+      where: {fingerprint: fingerprint},
+      transaction: options && options.transaction
+    })
+  }
+
   createEntry (values, options) {
     values.account = this.primary
     values.balance = this.balance
@@ -109,7 +116,13 @@ PersistentModelMixin(Account, sequelize, {
   password_hash: Sequelize.STRING,
   public_key: Sequelize.TEXT,
   is_admin: Sequelize.BOOLEAN,
-  is_disabled: Sequelize.BOOLEAN
-})
+  is_disabled: Sequelize.BOOLEAN,
+  fingerprint: Sequelize.STRING
+},
+  {
+    indexes: [
+      {fields: ['fingerprint']}
+    ]
+  })
 
 exports.Account = Account

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -3,6 +3,7 @@
 const bcrypt = require('bcrypt')
 const passport = require('koa-passport')
 const BasicStrategy = require('passport-http').BasicStrategy
+const ClientCertStrategy = require('five-bells-shared/middlewares/passport-client-cert')
 const HTTPSignatureStrategy = require('passport-http-signature')
 const AnonymousStrategy = require('passport-anonymous').Strategy
 const Account = require('../models/db/account').Account
@@ -53,6 +54,21 @@ passport.use(new HTTPSignatureStrategy(
         done(null, userObj, userObj.public_key)
       })
   }))
+
+passport.use(new ClientCertStrategy((fingerprint, info, done) => {
+  if (!config.getIn(['auth', 'client_certificates_enabled'])) {
+    return done(new UnauthorizedError('Unsupported authentication method'))
+  }
+
+  Account.findByFingerprint(fingerprint)
+    .then(function (userObj) {
+      if (!userObj || userObj.is_disabled || !userObj.fingerprint ||
+          !fingerprint || userObj.fingerprint !== fingerprint) {
+        return done(new UnauthorizedError('Unknown or invalid account'))
+      }
+      done(null, userObj)
+    })
+}))
 
 // Allow unauthenticated requests (transfers will just
 // be in the proposed state)

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -21,8 +21,9 @@ if (admin_pass) {
 }
 
 localConfig.auth = {
-  basic_enabled: Config.castBool(Config.getEnv('AUTH_BASIC_ENABLED'), true),
-  http_signature_enabled: Config.castBool(Config.getEnv('AUTH_HTTP_SIGNATURE_ENABLED'), true)
+  basic_enabled: Config.castBool(Config.getEnv(envPrefix, 'AUTH_BASIC_ENABLED'), true),
+  http_signature_enabled: Config.castBool(Config.getEnv(envPrefix, 'AUTH_HTTP_SIGNATURE_ENABLED'), true),
+  client_certificates_enabled: Config.castBool(Config.getEnv(envPrefix, 'AUTH_CLIENT_CERT_ENABLED'), true)
 }
 
 if (isRunningTests()) {


### PR DESCRIPTION
Depends on:

~~https://github.com/interledger/five-bells-shared/pull/50~~
~~https://github.com/interledger/five-bells-shared/pull/52~~

Working example:

Server
```diff
   _makeRouter () {
     const router = new Router()
-    router.get('/health', health.getResource)
+
+    router.get('/health',
+        passport.authenticate(['client-cert']),
+        health.getResource)

```

Client
```js
var fs = require('fs');
var https = require('https');

var options = {
  hostname: 'localhost',
  port: 3000,
  path: '/health',
  method: 'GET',
  key: fs.readFileSync('client1-key.pem'),
  cert: fs.readFileSync('client1-crt.pem'),
  ca: fs.readFileSync('ca-crt.pem') // Trust the test servers self-signed cert
};

var req = https.request(options, function(res) {
  res.on('data', function(data) {
    process.stdout.write(data);
  });
});
req.end();
```