### PR TITLE
Add /transfers/:id/fulfillment endpoint

### DIFF
--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -76,6 +76,13 @@ class App {
       models.Transfer.createBodyParser(),
       transfers.putResource)
 
+    router.put('/transfers/:id/fulfillment',
+      passport.authenticate(['basic', 'http-signature', 'anonymous'], {
+        session: false
+      }),
+      models.Transfer.createBodyParser(),
+      transfers.putResource)
+
     router.get('/transfers/:id', transfers.getResource)
     router.get('/transfers/:id/state', transfers.getStateResource)
 

--- a/test/putTransferSpec.js
+++ b/test/putTransferSpec.js
@@ -942,7 +942,7 @@ describe('PUT /transfers/:id', function () {
         .end()
 
       yield this.request()
-        .put(this.executedTransfer.id)
+        .put(this.executedTransfer.id + '/fulfillment')
         .send(transfer)
         .expect(200)
         .expect(_.assign({}, transfer, {


### PR DESCRIPTION
There will be more refactoring in the future to split the prepare and fulfillment logic into separate methods in the model, but this should be enough to get something working with the new notary API.