### PR TITLE
Split database layer from subscriptions and transfers models

### DIFF
--- a/src/models/db/accounts.js
+++ b/src/models/db/accounts.js
@@ -1,37 +1,50 @@
 'use strict'
 
+const assert = require('assert')
+const _ = require('lodash')
 const Account = require('./account').Account
 const db = require('../../services/db')
 
-function * getAccounts () {
-  return (yield Account.findAll())
+function * getAccounts (options) {
+  return (yield Account.findAll(options))
 }
 
-function * getConnectorAccounts () {
-  return (yield Account.findAll({
+function * getConnectorAccounts (options) {
+  return (yield Account.findAll(_.assign({}, options, {
     where: { connector: { $ne: null } }
-  }))
+  })))
 }
 
-function * getAccount (name) {
-  return (yield Account.findByName(name))
+function * getAccount (name, options) {
+  return (yield Account.findByName(name, options))
 }
 
-function * upsertAccount (account) {
+function * _upsertAccount (account, options) {
+  assert(options.transaction)
   // SQLite's implementation of upsert does not tell you whether it created the
   // row or whether it already existed. Since we need to know to return the
   // correct HTTP status code we unfortunately have to do this in two steps.
-  let existingAccount
-  yield db.transaction(function * (transaction) {
-    existingAccount = yield Account.findByName(account.name, { transaction })
-    if (existingAccount) {
-      existingAccount.setDataExternal(account)
-      yield existingAccount.save({ transaction })
-    } else {
-      yield Account.createExternal(account, { transaction })
-    }
-  })
+  const existingAccount = yield Account.findByName(account.name, options)
+  if (existingAccount) {
+    existingAccount.setDataExternal(account)
+    yield existingAccount.save(options)
+  } else {
+    yield Account.createExternal(account, options)
+  }
   return Boolean(existingAccount)
+}
+
+function * upsertAccount (account, options) {
+  if (options && options.transaction) {
+    return (yield _upsertAccount(account, options))
+  } else {
+    let result
+    yield db.transaction(function * (transaction) {
+      result = yield _upsertAccount(account,
+        _.assign({}, options || {}, {transaction}))
+    })
+    return result
+  }
 }
 
 module.exports = {

--- a/src/models/db/subscriptions.js
+++ b/src/models/db/subscriptions.js
@@ -1,0 +1,55 @@
+'use strict'
+
+const assert = require('assert')
+const _ = require('lodash')
+const db = require('../../services/db')
+const Subscription = require('./subscription').Subscription
+
+function * getSubscription (id, options) {
+  return (yield Subscription.findById(id, options))
+}
+
+function * getMatchingSubscription (subscription, options) {
+  return (yield Subscription.findOne({where: {
+    event: subscription.event,
+    subject: subscription.subject,
+    target: subscription.target
+  }
+  }, options))
+}
+
+function * _upsertSubscription (subscription, options) {
+  assert(options.transaction)
+  // SQLite's implementation of upsert does not tell you whether it created the
+  // row or whether it already existed. Since we need to know to return the
+  // correct HTTP status code we unfortunately have to do this in two steps.
+  const existingSubscription = yield Subscription.findById(
+    subscription.id, options)
+  yield Subscription.upsert(subscription, options)
+  return Boolean(existingSubscription)
+}
+
+function * upsertSubscription (subscription, options) {
+  if (options && options.transaction) {
+    return (yield _upsertSubscription(subscription, options))
+  } else {
+    let result
+    yield db.transaction(function * (transaction) {
+      result = yield _upsertSubscription(subscription,
+        _.assign({}, options || {}, {transaction}))
+    })
+    return result
+  }
+}
+
+function * deleteSubscription (id, options) {
+  Subscription.DbModel.destroy(_.assign({}, options, {where: {id: id}}))
+}
+
+module.exports = {
+  getSubscription,
+  getMatchingSubscription,
+  upsertSubscription,
+  deleteSubscription,
+  transaction: db.transaction.bind(db)
+}

--- a/src/models/db/transfers.js
+++ b/src/models/db/transfers.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const db = require('../../services/db')
+const Transfer = require('./transfer').Transfer
+
+function * getTransfer (id, options) {
+  return (yield Transfer.findById(id, options))
+}
+
+function * upsertTransfer (transfer, options) {
+  yield Transfer.upsert(transfer, options)
+}
+
+module.exports = {
+  getTransfer,
+  upsertTransfer,
+  transaction: db.transaction.bind(db)
+}


### PR DESCRIPTION
This completes the method extraction for the models in this repo.

Remaining work in this refactoring:
1. Use POJOs in interface between db methods and models
2. Use db methods in "lib"