### PR TITLE
Server-side Client Certificate Authentication

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,106 +4,106 @@
   "dependencies": {
     "bcrypt": {
       "version": "0.8.5",
-      "from": "bcrypt@>=0.8.5 <0.9.0",
+      "from": "https://registry.npmjs.org/bcrypt/-/bcrypt-0.8.5.tgz",
       "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-0.8.5.tgz",
       "dependencies": {
         "bindings": {
           "version": "1.2.1",
-          "from": "bindings@1.2.1",
+          "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
           "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
         },
         "nan": {
           "version": "2.0.5",
-          "from": "nan@2.0.5",
+          "from": "https://registry.npmjs.org/nan/-/nan-2.0.5.tgz",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.5.tgz"
         }
       }
     },
     "canonical-json": {
       "version": "0.0.4",
-      "from": "canonical-json@0.0.4",
+      "from": "https://registry.npmjs.org/canonical-json/-/canonical-json-0.0.4.tgz",
       "resolved": "https://registry.npmjs.org/canonical-json/-/canonical-json-0.0.4.tgz"
     },
     "co": {
       "version": "4.6.0",
-      "from": "co@>=4.1.0 <5.0.0",
+      "from": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
     },
     "co-defer": {
       "version": "1.0.0",
-      "from": "co-defer@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/co-defer/-/co-defer-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/co-defer/-/co-defer-1.0.0.tgz"
     },
     "co-emitter": {
       "version": "0.2.3",
-      "from": "co-emitter@>=0.2.3 <0.3.0",
+      "from": "https://registry.npmjs.org/co-emitter/-/co-emitter-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/co-emitter/-/co-emitter-0.2.3.tgz"
     },
     "co-request": {
       "version": "1.0.0",
-      "from": "co-request@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/co-request/-/co-request-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/co-request/-/co-request-1.0.0.tgz",
       "dependencies": {
         "request": {
           "version": "2.69.0",
-          "from": "request@*",
+          "from": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
-              "from": "aws-sign2@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
             },
             "aws4": {
               "version": "1.2.1",
-              "from": "aws4@>=1.2.1 <2.0.0",
+              "from": "https://registry.npmjs.org/aws4/-/aws4-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.2.1.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.7.3",
-                  "from": "lru-cache@>=2.6.5 <3.0.0",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                 }
               }
             },
             "bl": {
               "version": "1.0.3",
-              "from": "bl@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.5",
-                  "from": "readable-stream@>=2.0.5 <2.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
@@ -112,148 +112,148 @@
             },
             "caseless": {
               "version": "0.11.0",
-              "from": "caseless@>=0.11.0 <0.12.0",
+              "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
             },
             "combined-stream": {
               "version": "1.0.5",
-              "from": "combined-stream@>=1.0.5 <1.1.0",
+              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "from": "delayed-stream@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 }
               }
             },
             "extend": {
               "version": "3.0.0",
-              "from": "extend@>=3.0.0 <3.1.0",
+              "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             },
             "forever-agent": {
               "version": "0.6.1",
-              "from": "forever-agent@>=0.6.1 <0.7.0",
+              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
               "version": "1.0.0-rc3",
-              "from": "form-data@>=1.0.0-rc3 <1.1.0",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
               "dependencies": {
                 "async": {
                   "version": "1.5.2",
-                  "from": "async@>=1.4.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
                 }
               }
             },
             "har-validator": {
               "version": "2.0.6",
-              "from": "har-validator@>=2.0.6 <2.1.0",
+              "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
               "dependencies": {
                 "chalk": {
                   "version": "1.1.1",
-                  "from": "chalk@>=1.1.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.1.0",
-                      "from": "ansi-styles@>=2.1.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                     },
                     "escape-string-regexp": {
                       "version": "1.0.4",
-                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                     },
                     "has-ansi": {
                       "version": "2.0.0",
-                      "from": "has-ansi@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "3.0.0",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "supports-color": {
                       "version": "2.0.0",
-                      "from": "supports-color@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                     }
                   }
                 },
                 "commander": {
                   "version": "2.9.0",
-                  "from": "commander@>=2.9.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
+                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "is-my-json-valid": {
                   "version": "2.13.0",
-                  "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+                  "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.0.tgz",
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "from": "generate-function@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "from": "is-property@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "2.0.0",
-                      "from": "jsonpointer@2.0.0",
+                      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
                 "pinkie-promise": {
                   "version": "2.0.0",
-                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.4",
-                      "from": "pinkie@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                     }
                   }
@@ -262,98 +262,98 @@
             },
             "hawk": {
               "version": "3.1.3",
-              "from": "hawk@>=3.1.0 <3.2.0",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "2.16.3",
-                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                 },
                 "boom": {
                   "version": "2.10.1",
-                  "from": "boom@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "http-signature": {
               "version": "1.1.1",
-              "from": "http-signature@>=1.1.0 <1.2.0",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.2.0",
-                  "from": "assert-plus@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                 },
                 "jsprim": {
                   "version": "1.2.2",
-                  "from": "jsprim@>=1.2.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
                   "dependencies": {
                     "extsprintf": {
                       "version": "1.0.2",
-                      "from": "extsprintf@1.0.2",
+                      "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                     },
                     "json-schema": {
                       "version": "0.2.2",
-                      "from": "json-schema@0.2.2",
+                      "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
                     },
                     "verror": {
                       "version": "1.3.6",
-                      "from": "verror@1.3.6",
+                      "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
                       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                     }
                   }
                 },
                 "sshpk": {
                   "version": "1.7.4",
-                  "from": "sshpk@>=1.7.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz",
                   "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz",
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
-                      "from": "asn1@>=0.2.3 <0.3.0",
+                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                     },
                     "dashdash": {
                       "version": "1.13.0",
-                      "from": "dashdash@>=1.10.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
                       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
                       "dependencies": {
                         "assert-plus": {
                           "version": "1.0.0",
-                          "from": "assert-plus@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                         }
                       }
                     },
                     "jsbn": {
                       "version": "0.1.0",
-                      "from": "jsbn@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                     },
                     "jodid25519": {
                       "version": "1.0.2",
-                      "from": "jodid25519@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                     },
                     "ecc-jsbn": {
                       "version": "0.1.1",
-                      "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+                      "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                     }
                   }
@@ -362,59 +362,59 @@
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "from": "is-typedarray@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "isstream@>=0.1.2 <0.2.0",
+              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
               "version": "2.1.10",
-              "from": "mime-types@>=2.1.7 <2.2.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.22.0",
-                  "from": "mime-db@>=1.22.0 <1.23.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.7",
-              "from": "node-uuid@>=1.4.7 <1.5.0",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "oauth-sign": {
               "version": "0.8.1",
-              "from": "oauth-sign@>=0.8.0 <0.9.0",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
             },
             "qs": {
               "version": "6.0.2",
-              "from": "qs@>=6.0.2 <6.1.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
             },
             "stringstream": {
               "version": "0.0.5",
-              "from": "stringstream@>=0.0.4 <0.1.0",
+              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
             },
             "tough-cookie": {
               "version": "2.2.1",
-              "from": "tough-cookie@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.2",
-              "from": "tunnel-agent@>=0.4.1 <0.5.0",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
             }
           }
@@ -423,32 +423,32 @@
     },
     "deep-diff": {
       "version": "0.3.3",
-      "from": "deep-diff@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.3.tgz",
       "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.3.tgz"
     },
     "five-bells-condition": {
       "version": "2.0.0",
-      "from": "five-bells-condition@>=2.0.0 <2.1.0",
+      "from": "https://registry.npmjs.org/five-bells-condition/-/five-bells-condition-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/five-bells-condition/-/five-bells-condition-2.0.0.tgz",
       "dependencies": {
         "tv4": {
           "version": "1.2.7",
-          "from": "tv4@>=1.2.7 <2.0.0",
+          "from": "https://registry.npmjs.org/tv4/-/tv4-1.2.7.tgz",
           "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.2.7.tgz"
         },
         "tv4-formats": {
           "version": "1.0.2",
-          "from": "tv4-formats@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/tv4-formats/-/tv4-formats-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/tv4-formats/-/tv4-formats-1.0.2.tgz",
           "dependencies": {
             "validator": {
               "version": "4.9.0",
-              "from": "validator@>=4.2.0 <5.0.0",
+              "from": "https://registry.npmjs.org/validator/-/validator-4.9.0.tgz",
               "resolved": "https://registry.npmjs.org/validator/-/validator-4.9.0.tgz",
               "dependencies": {
                 "depd": {
                   "version": "1.1.0",
-                  "from": "depd@1.1.0",
+                  "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
                 }
               }
@@ -459,32 +459,32 @@
     },
     "five-bells-shared": {
       "version": "9.2.1",
-      "from": "five-bells-shared@>=9.2.1 <9.3.0",
+      "from": "https://registry.npmjs.org/five-bells-shared/-/five-bells-shared-9.2.1.tgz",
       "resolved": "https://registry.npmjs.org/five-bells-shared/-/five-bells-shared-9.2.1.tgz",
       "dependencies": {
         "co-body": {
           "version": "1.2.0",
-          "from": "co-body@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/co-body/-/co-body-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/co-body/-/co-body-1.2.0.tgz",
           "dependencies": {
             "qs": {
               "version": "2.3.3",
-              "from": "qs@>=2.3.3 <2.4.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
             },
             "raw-body": {
               "version": "1.3.4",
-              "from": "raw-body@>=1.3.3 <1.4.0",
+              "from": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.4.tgz",
               "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.4.tgz",
               "dependencies": {
                 "bytes": {
                   "version": "1.0.0",
-                  "from": "bytes@1.0.0",
+                  "from": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
                 },
                 "iconv-lite": {
                   "version": "0.4.8",
-                  "from": "iconv-lite@0.4.8",
+                  "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz",
                   "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz"
                 }
               }
@@ -493,93 +493,93 @@
         },
         "immutable": {
           "version": "3.7.6",
-          "from": "immutable@>=3.7.6 <4.0.0",
+          "from": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
           "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz"
         },
         "mag-colored-output": {
           "version": "1.0.1",
-          "from": "mag-colored-output@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/mag-colored-output/-/mag-colored-output-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/mag-colored-output/-/mag-colored-output-1.0.1.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.1.1",
-              "from": "chalk@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.4",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "readable-stream": {
               "version": "2.0.5",
-              "from": "readable-stream@>=2.0.2 <3.0.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
@@ -588,32 +588,32 @@
         },
         "mag-format-message": {
           "version": "0.1.1",
-          "from": "mag-format-message@>=0.1.1 <0.2.0",
+          "from": "https://registry.npmjs.org/mag-format-message/-/mag-format-message-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/mag-format-message/-/mag-format-message-0.1.1.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@>=1.1.12 <2.0.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -622,34 +622,34 @@
         },
         "path-to-regexp": {
           "version": "1.2.1",
-          "from": "path-to-regexp@>=1.2.0 <2.0.0",
+          "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.2.1.tgz",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.2.1.tgz",
           "dependencies": {
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             }
           }
         },
         "retry-as-promised": {
           "version": "2.0.1",
-          "from": "retry-as-promised@>=2.0.1 <3.0.0",
+          "from": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-2.0.1.tgz",
           "dependencies": {
             "bluebird": {
               "version": "3.3.1",
-              "from": "bluebird@>=3.1.1 <4.0.0",
+              "from": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
               "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz"
             },
             "debug": {
               "version": "2.2.0",
-              "from": "debug@>=2.2.0 <3.0.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
@@ -658,61 +658,61 @@
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.3 <0.7.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
         "tv4": {
           "version": "1.2.7",
-          "from": "tv4@>=1.2.7 <2.0.0",
+          "from": "https://registry.npmjs.org/tv4/-/tv4-1.2.7.tgz",
           "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.2.7.tgz"
         },
         "tv4-formats": {
           "version": "1.0.2",
-          "from": "tv4-formats@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/tv4-formats/-/tv4-formats-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/tv4-formats/-/tv4-formats-1.0.2.tgz",
           "dependencies": {
             "validator": {
               "version": "4.9.0",
-              "from": "validator@>=4.2.0 <5.0.0",
+              "from": "https://registry.npmjs.org/validator/-/validator-4.9.0.tgz",
               "resolved": "https://registry.npmjs.org/validator/-/validator-4.9.0.tgz",
               "dependencies": {
                 "depd": {
                   "version": "1.1.0",
-                  "from": "depd@1.1.0",
+                  "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
                 }
               }
@@ -723,110 +723,110 @@
     },
     "koa": {
       "version": "1.1.2",
-      "from": "koa@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/koa/-/koa-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/koa/-/koa-1.1.2.tgz",
       "dependencies": {
         "accepts": {
           "version": "1.3.1",
-          "from": "accepts@>=1.2.2 <2.0.0",
+          "from": "https://registry.npmjs.org/accepts/-/accepts-1.3.1.tgz",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.1.tgz",
           "dependencies": {
             "negotiator": {
               "version": "0.6.0",
-              "from": "negotiator@0.6.0",
+              "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.0.tgz",
               "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.0.tgz"
             }
           }
         },
         "composition": {
           "version": "2.2.1",
-          "from": "composition@>=2.1.1 <3.0.0",
+          "from": "https://registry.npmjs.org/composition/-/composition-2.2.1.tgz",
           "resolved": "https://registry.npmjs.org/composition/-/composition-2.2.1.tgz",
           "dependencies": {
             "native-or-bluebird": {
               "version": "1.2.0",
-              "from": "native-or-bluebird@>=1.1.2 <2.0.0",
+              "from": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.2.0.tgz"
             }
           }
         },
         "content-disposition": {
           "version": "0.5.1",
-          "from": "content-disposition@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
         },
         "content-type": {
           "version": "1.0.1",
-          "from": "content-type@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
         },
         "cookies": {
           "version": "0.5.1",
-          "from": "cookies@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/cookies/-/cookies-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.5.1.tgz",
           "dependencies": {
             "keygrip": {
               "version": "1.0.1",
-              "from": "keygrip@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.1.tgz"
             }
           }
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@*",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "delegates": {
           "version": "0.1.0",
-          "from": "delegates@0.1.0",
+          "from": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
         },
         "destroy": {
           "version": "1.0.4",
-          "from": "destroy@>=1.0.3 <2.0.0",
+          "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
         },
         "error-inject": {
           "version": "1.0.0",
-          "from": "error-inject@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/error-inject/-/error-inject-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/error-inject/-/error-inject-1.0.0.tgz"
         },
         "escape-html": {
           "version": "1.0.3",
-          "from": "escape-html@>=1.0.1 <1.1.0",
+          "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
         },
         "fresh": {
           "version": "0.3.0",
-          "from": "fresh@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
         },
         "http-assert": {
           "version": "1.1.1",
-          "from": "http-assert@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/http-assert/-/http-assert-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.1.1.tgz",
           "dependencies": {
             "deep-equal": {
               "version": "1.0.1",
-              "from": "deep-equal@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
             },
             "http-errors": {
               "version": "1.3.1",
-              "from": "http-errors@>=1.3.1 <1.4.0",
+              "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -835,163 +835,163 @@
         },
         "http-errors": {
           "version": "1.4.0",
-          "from": "http-errors@>=1.3.1 <2.0.0",
+          "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "koa-compose": {
           "version": "2.3.0",
-          "from": "koa-compose@>=2.3.0 <3.0.0",
+          "from": "https://registry.npmjs.org/koa-compose/-/koa-compose-2.3.0.tgz",
           "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-2.3.0.tgz"
         },
         "koa-is-json": {
           "version": "1.0.0",
-          "from": "koa-is-json@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/koa-is-json/-/koa-is-json-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/koa-is-json/-/koa-is-json-1.0.0.tgz"
         },
         "mime-types": {
           "version": "2.1.10",
-          "from": "mime-types@>=2.0.7 <3.0.0",
+          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
           "dependencies": {
             "mime-db": {
               "version": "1.22.0",
-              "from": "mime-db@>=1.22.0 <1.23.0",
+              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
             }
           }
         },
         "on-finished": {
           "version": "2.3.0",
-          "from": "on-finished@>=2.1.0 <3.0.0",
+          "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.1",
-              "from": "ee-first@1.1.1",
+              "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
             }
           }
         },
         "only": {
           "version": "0.0.2",
-          "from": "only@0.0.2",
+          "from": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz"
         },
         "parseurl": {
           "version": "1.3.1",
-          "from": "parseurl@>=1.3.0 <2.0.0",
+          "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
         },
         "statuses": {
           "version": "1.2.1",
-          "from": "statuses@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
         },
         "type-is": {
           "version": "1.6.11",
-          "from": "type-is@>=1.5.5 <2.0.0",
+          "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.11.tgz",
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.11.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
-              "from": "media-typer@0.3.0",
+              "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             }
           }
         },
         "vary": {
           "version": "1.1.0",
-          "from": "vary@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
         }
       }
     },
     "koa-compress": {
       "version": "1.0.9",
-      "from": "koa-compress@>=1.0.6 <2.0.0",
+      "from": "https://registry.npmjs.org/koa-compress/-/koa-compress-1.0.9.tgz",
       "resolved": "https://registry.npmjs.org/koa-compress/-/koa-compress-1.0.9.tgz",
       "dependencies": {
         "bytes": {
           "version": "2.3.0",
-          "from": "bytes@>=2.3.0 <3.0.0",
+          "from": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz"
         },
         "compressible": {
           "version": "2.0.7",
-          "from": "compressible@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/compressible/-/compressible-2.0.7.tgz",
           "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.7.tgz",
           "dependencies": {
             "mime-db": {
               "version": "1.22.0",
-              "from": "mime-db@>=1.21.0 <2.0.0",
+              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
             }
           }
         },
         "koa-is-json": {
           "version": "1.0.0",
-          "from": "koa-is-json@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/koa-is-json/-/koa-is-json-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/koa-is-json/-/koa-is-json-1.0.0.tgz"
         },
         "statuses": {
           "version": "1.2.1",
-          "from": "statuses@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
         }
       }
     },
     "koa-cors": {
       "version": "0.0.16",
-      "from": "koa-cors@0.0.16",
+      "from": "https://registry.npmjs.org/koa-cors/-/koa-cors-0.0.16.tgz",
       "resolved": "https://registry.npmjs.org/koa-cors/-/koa-cors-0.0.16.tgz"
     },
     "koa-mag": {
       "version": "1.1.0",
-      "from": "koa-mag@>=1.0.4 <2.0.0",
+      "from": "https://registry.npmjs.org/koa-mag/-/koa-mag-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/koa-mag/-/koa-mag-1.1.0.tgz",
       "dependencies": {
         "bytes": {
           "version": "1.0.0",
-          "from": "bytes@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
         },
         "humanize-number": {
           "version": "0.0.2",
-          "from": "humanize-number@>=0.0.1 <0.1.0",
+          "from": "https://registry.npmjs.org/humanize-number/-/humanize-number-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/humanize-number/-/humanize-number-0.0.2.tgz"
         },
         "passthrough-counter": {
           "version": "0.0.1",
-          "from": "passthrough-counter@>=0.0.1 <0.1.0",
+          "from": "https://registry.npmjs.org/passthrough-counter/-/passthrough-counter-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/passthrough-counter/-/passthrough-counter-0.0.1.tgz"
         }
       }
     },
     "koa-passport": {
       "version": "1.2.0",
-      "from": "koa-passport@>=1.1.6 <2.0.0",
+      "from": "https://registry.npmjs.org/koa-passport/-/koa-passport-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/koa-passport/-/koa-passport-1.2.0.tgz",
       "dependencies": {
         "passport": {
           "version": "0.3.2",
-          "from": "passport@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/passport/-/passport-0.3.2.tgz",
           "resolved": "https://registry.npmjs.org/passport/-/passport-0.3.2.tgz",
           "dependencies": {
             "passport-strategy": {
               "version": "1.0.0",
-              "from": "passport-strategy@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz"
             },
             "pause": {
               "version": "0.0.1",
-              "from": "pause@0.0.1",
+              "from": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
             }
           }
@@ -1000,46 +1000,46 @@
     },
     "koa-router": {
       "version": "5.4.0",
-      "from": "koa-router@>=5.1.2 <6.0.0",
+      "from": "https://registry.npmjs.org/koa-router/-/koa-router-5.4.0.tgz",
       "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-5.4.0.tgz",
       "dependencies": {
         "debug": {
           "version": "2.2.0",
-          "from": "debug@>=2.2.0 <3.0.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "http-errors": {
           "version": "1.4.0",
-          "from": "http-errors@>=1.3.1 <2.0.0",
+          "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "statuses": {
               "version": "1.2.1",
-              "from": "statuses@>=1.2.1 <2.0.0",
+              "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
             }
           }
         },
         "path-to-regexp": {
           "version": "1.2.1",
-          "from": "path-to-regexp@>=1.1.1 <2.0.0",
+          "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.2.1.tgz",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.2.1.tgz",
           "dependencies": {
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             }
           }
@@ -1048,49 +1048,49 @@
     },
     "koa-static": {
       "version": "1.5.2",
-      "from": "koa-static@>=1.4.5 <2.0.0",
+      "from": "https://registry.npmjs.org/koa-static/-/koa-static-1.5.2.tgz",
       "resolved": "https://registry.npmjs.org/koa-static/-/koa-static-1.5.2.tgz",
       "dependencies": {
         "debug": {
           "version": "2.2.0",
-          "from": "debug@*",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "koa-send": {
           "version": "2.0.2",
-          "from": "koa-send@>=2.0.1 <2.1.0",
+          "from": "https://registry.npmjs.org/koa-send/-/koa-send-2.0.2.tgz",
           "resolved": "https://registry.npmjs.org/koa-send/-/koa-send-2.0.2.tgz",
           "dependencies": {
             "mz": {
               "version": "2.3.1",
-              "from": "mz@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/mz/-/mz-2.3.1.tgz",
               "resolved": "https://registry.npmjs.org/mz/-/mz-2.3.1.tgz",
               "dependencies": {
                 "any-promise": {
                   "version": "1.1.0",
-                  "from": "any-promise@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/any-promise/-/any-promise-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.1.0.tgz"
                 },
                 "object-assign": {
                   "version": "4.0.1",
-                  "from": "object-assign@>=4.0.1 <5.0.0",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
                 },
                 "thenify-all": {
                   "version": "1.6.0",
-                  "from": "thenify-all@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
                   "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
                   "dependencies": {
                     "thenify": {
                       "version": "3.2.0",
-                      "from": "thenify@>=3.1.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/thenify/-/thenify-3.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.2.0.tgz"
                     }
                   }
@@ -1099,29 +1099,29 @@
             },
             "resolve-path": {
               "version": "1.3.0",
-              "from": "resolve-path@>=1.2.1 <2.0.0",
+              "from": "https://registry.npmjs.org/resolve-path/-/resolve-path-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/resolve-path/-/resolve-path-1.3.0.tgz",
               "dependencies": {
                 "http-errors": {
                   "version": "1.3.1",
-                  "from": "http-errors@>=1.3.1 <1.4.0",
+                  "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "statuses": {
                       "version": "1.2.1",
-                      "from": "statuses@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "from": "path-is-absolute@1.0.0",
+                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 }
               }
@@ -1132,52 +1132,52 @@
     },
     "lodash": {
       "version": "3.10.1",
-      "from": "lodash@>=3.5.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
     },
     "mag": {
       "version": "0.9.1",
-      "from": "mag@>=0.9.1 <0.10.0",
+      "from": "https://registry.npmjs.org/mag/-/mag-0.9.1.tgz",
       "resolved": "https://registry.npmjs.org/mag/-/mag-0.9.1.tgz",
       "dependencies": {
         "mag-logger-facade": {
           "version": "0.9.0",
-          "from": "mag-logger-facade@0.9.0",
+          "from": "https://registry.npmjs.org/mag-logger-facade/-/mag-logger-facade-0.9.0.tgz",
           "resolved": "https://registry.npmjs.org/mag-logger-facade/-/mag-logger-facade-0.9.0.tgz"
         },
         "mag-stream": {
           "version": "0.9.0",
-          "from": "mag-stream@>=0.9.0 <0.10.0",
+          "from": "https://registry.npmjs.org/mag-stream/-/mag-stream-0.9.0.tgz",
           "resolved": "https://registry.npmjs.org/mag-stream/-/mag-stream-0.9.0.tgz",
           "dependencies": {
             "mag-fallback": {
               "version": "0.9.1",
-              "from": "mag-fallback@>=0.9.0 <0.10.0",
+              "from": "https://registry.npmjs.org/mag-fallback/-/mag-fallback-0.9.1.tgz",
               "resolved": "https://registry.npmjs.org/mag-fallback/-/mag-fallback-0.9.1.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.13 <2.0.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -1190,32 +1190,32 @@
     },
     "mag-hub": {
       "version": "0.1.1",
-      "from": "mag-hub@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/mag-hub/-/mag-hub-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/mag-hub/-/mag-hub-0.1.1.tgz",
       "dependencies": {
         "readable-stream": {
           "version": "1.1.13",
-          "from": "readable-stream@>=1.1.12 <2.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "string_decoder@>=0.10.0 <0.11.0",
+              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
@@ -1224,47 +1224,47 @@
     },
     "methods": {
       "version": "1.1.2",
-      "from": "methods@>=1.1.1 <2.0.0",
+      "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
     },
     "moment": {
       "version": "2.11.2",
-      "from": "moment@>=2.10.2 <3.0.0",
+      "from": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz"
     },
     "mysql": {
       "version": "2.10.2",
-      "from": "mysql@>=2.9.0 <3.0.0",
+      "from": "https://registry.npmjs.org/mysql/-/mysql-2.10.2.tgz",
       "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.10.2.tgz",
       "dependencies": {
         "bignumber.js": {
           "version": "2.1.4",
-          "from": "bignumber.js@2.1.4",
+          "from": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-2.1.4.tgz",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-2.1.4.tgz"
         },
         "readable-stream": {
           "version": "1.1.13",
-          "from": "readable-stream@>=1.1.13 <1.2.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "string_decoder@>=0.10.0 <0.11.0",
+              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "inherits@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
@@ -1273,86 +1273,86 @@
     },
     "nodemon": {
       "version": "1.8.1",
-      "from": "nodemon@>=1.3.5 <2.0.0",
+      "from": "https://registry.npmjs.org/nodemon/-/nodemon-1.8.1.tgz",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.8.1.tgz",
       "dependencies": {
         "chokidar": {
           "version": "1.4.2",
-          "from": "chokidar@>=1.2.0 <2.0.0",
+          "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.2.tgz",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.2.tgz",
           "dependencies": {
             "anymatch": {
               "version": "1.3.0",
-              "from": "anymatch@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "dependencies": {
                 "arrify": {
                   "version": "1.0.1",
-                  "from": "arrify@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
                 },
                 "micromatch": {
                   "version": "2.3.7",
-                  "from": "micromatch@>=2.1.5 <3.0.0",
+                  "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz",
                   "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz",
                   "dependencies": {
                     "arr-diff": {
                       "version": "2.0.0",
-                      "from": "arr-diff@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                       "dependencies": {
                         "arr-flatten": {
                           "version": "1.0.1",
-                          "from": "arr-flatten@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
                         }
                       }
                     },
                     "array-unique": {
                       "version": "0.2.1",
-                      "from": "array-unique@>=0.2.1 <0.3.0",
+                      "from": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
                     },
                     "braces": {
                       "version": "1.8.3",
-                      "from": "braces@>=1.8.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz",
                       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz",
                       "dependencies": {
                         "expand-range": {
                           "version": "1.8.1",
-                          "from": "expand-range@>=1.8.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "dependencies": {
                             "fill-range": {
                               "version": "2.2.3",
-                              "from": "fill-range@>=2.1.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                               "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                               "dependencies": {
                                 "is-number": {
                                   "version": "2.1.0",
-                                  "from": "is-number@>=2.1.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
                                 },
                                 "isobject": {
                                   "version": "2.0.0",
-                                  "from": "isobject@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
                                   "dependencies": {
                                     "isarray": {
                                       "version": "0.0.1",
-                                      "from": "isarray@0.0.1",
+                                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                     }
                                   }
                                 },
                                 "randomatic": {
                                   "version": "1.1.5",
-                                  "from": "randomatic@>=1.1.3 <2.0.0",
+                                  "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
                                   "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                 }
                               }
@@ -1361,107 +1361,107 @@
                         },
                         "preserve": {
                           "version": "0.2.0",
-                          "from": "preserve@>=0.2.0 <0.3.0",
+                          "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                         },
                         "repeat-element": {
                           "version": "1.1.2",
-                          "from": "repeat-element@>=1.1.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                         }
                       }
                     },
                     "expand-brackets": {
                       "version": "0.1.4",
-                      "from": "expand-brackets@>=0.1.4 <0.2.0",
+                      "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz",
                       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
                     },
                     "extglob": {
                       "version": "0.3.2",
-                      "from": "extglob@>=0.3.1 <0.4.0",
+                      "from": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
                       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
                     },
                     "filename-regex": {
                       "version": "2.0.0",
-                      "from": "filename-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                     },
                     "is-extglob": {
                       "version": "1.0.0",
-                      "from": "is-extglob@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                     },
                     "kind-of": {
                       "version": "3.0.2",
-                      "from": "kind-of@>=3.0.2 <4.0.0",
+                      "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                       "dependencies": {
                         "is-buffer": {
                           "version": "1.1.2",
-                          "from": "is-buffer@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
                         }
                       }
                     },
                     "normalize-path": {
                       "version": "2.0.1",
-                      "from": "normalize-path@>=2.0.1 <3.0.0",
+                      "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
                     },
                     "object.omit": {
                       "version": "2.0.0",
-                      "from": "object.omit@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
                       "dependencies": {
                         "for-own": {
                           "version": "0.1.3",
-                          "from": "for-own@>=0.1.3 <0.2.0",
+                          "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                           "dependencies": {
                             "for-in": {
                               "version": "0.1.4",
-                              "from": "for-in@>=0.1.4 <0.2.0",
+                              "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz",
                               "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
                             }
                           }
                         },
                         "is-extendable": {
                           "version": "0.1.1",
-                          "from": "is-extendable@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
                         }
                       }
                     },
                     "parse-glob": {
                       "version": "3.0.4",
-                      "from": "parse-glob@>=3.0.4 <4.0.0",
+                      "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
                       "dependencies": {
                         "glob-base": {
                           "version": "0.3.0",
-                          "from": "glob-base@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
                         },
                         "is-dotfile": {
                           "version": "1.0.2",
-                          "from": "is-dotfile@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
                         }
                       }
                     },
                     "regex-cache": {
                       "version": "0.4.2",
-                      "from": "regex-cache@>=0.4.2 <0.5.0",
+                      "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                       "dependencies": {
                         "is-equal-shallow": {
                           "version": "0.1.3",
-                          "from": "is-equal-shallow@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
                         },
                         "is-primitive": {
                           "version": "2.0.0",
-                          "from": "is-primitive@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                         }
                       }
@@ -1472,76 +1472,76 @@
             },
             "async-each": {
               "version": "0.1.6",
-              "from": "async-each@>=0.1.6 <0.2.0",
+              "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
               "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
             },
             "glob-parent": {
               "version": "2.0.0",
-              "from": "glob-parent@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <3.0.0",
+              "from": "inherits@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "is-binary-path": {
               "version": "1.0.1",
-              "from": "is-binary-path@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
               "dependencies": {
                 "binary-extensions": {
                   "version": "1.4.0",
-                  "from": "binary-extensions@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
                 }
               }
             },
             "is-glob": {
               "version": "2.0.1",
-              "from": "is-glob@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
               "dependencies": {
                 "is-extglob": {
                   "version": "1.0.0",
-                  "from": "is-extglob@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             },
             "readdirp": {
               "version": "2.0.0",
-              "from": "readdirp@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "4.1.3",
-                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                 },
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "minimatch@>=2.0.10 <3.0.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.3",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.3.0",
-                          "from": "balanced-match@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -1550,32 +1550,32 @@
                 },
                 "readable-stream": {
                   "version": "2.0.5",
-                  "from": "readable-stream@>=2.0.2 <3.0.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
@@ -1584,12 +1584,12 @@
             },
             "fsevents": {
               "version": "1.0.7",
-              "from": "fsevents@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.7.tgz",
               "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.7.tgz",
               "dependencies": {
                 "nan": {
                   "version": "2.2.0",
-                  "from": "nan@>=2.1.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz"
                 },
                 "node-pre-gyp": {
@@ -1646,6 +1646,11 @@
                   "from": "async@^1.4.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-1.5.1.tgz"
                 },
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "from": "aws-sign2@~0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                },
                 "bl": {
                   "version": "1.0.0",
                   "from": "bl@~1.0.0",
@@ -1655,11 +1660,6 @@
                   "version": "0.0.8",
                   "from": "block-stream@*",
                   "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
-                },
-                "aws-sign2": {
-                  "version": "0.6.0",
-                  "from": "aws-sign2@~0.6.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
                 },
                 "boom": {
                   "version": "2.10.1",
@@ -1686,30 +1686,30 @@
                   "from": "commander@^2.9.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
                 },
-                "cryptiles": {
-                  "version": "2.0.5",
-                  "from": "cryptiles@2.x.x",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                },
                 "core-util-is": {
                   "version": "1.0.2",
                   "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "from": "cryptiles@2.x.x",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                 },
                 "dashdash": {
                   "version": "1.11.0",
                   "from": "dashdash@>=1.10.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.11.0.tgz"
                 },
-                "deep-extend": {
-                  "version": "0.4.0",
-                  "from": "deep-extend@~0.4.0",
-                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz"
-                },
                 "debug": {
                   "version": "0.7.4",
                   "from": "debug@~0.7.2",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                },
+                "deep-extend": {
+                  "version": "0.4.0",
+                  "from": "deep-extend@~0.4.0",
+                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz"
                 },
                 "delayed-stream": {
                   "version": "1.0.0",
@@ -1726,15 +1726,15 @@
                   "from": "ecc-jsbn@>=0.0.1 <1.0.0",
                   "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                 },
-                "extend": {
-                  "version": "3.0.0",
-                  "from": "extend@~3.0.0",
-                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-                },
                 "escape-string-regexp": {
                   "version": "1.0.4",
                   "from": "escape-string-regexp@^1.0.2",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                },
+                "extend": {
+                  "version": "3.0.0",
+                  "from": "extend@~3.0.0",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                 },
                 "extsprintf": {
                   "version": "1.0.2",
@@ -1801,11 +1801,6 @@
                   "from": "hawk@~3.1.0",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz"
                 },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@*",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
                 "hoek": {
                   "version": "2.16.3",
                   "from": "hoek@2.x.x",
@@ -1816,20 +1811,25 @@
                   "from": "http-signature@~1.1.0",
                   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz"
                 },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@*",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
                 "ini": {
                   "version": "1.3.4",
                   "from": "ini@~1.3.0",
                   "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                 },
-                "is-property": {
-                  "version": "1.0.2",
-                  "from": "is-property@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-                },
                 "is-my-json-valid": {
                   "version": "2.12.3",
                   "from": "is-my-json-valid@^2.12.3",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz"
+                },
+                "is-property": {
+                  "version": "1.0.2",
+                  "from": "is-property@^1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                 },
                 "is-typedarray": {
                   "version": "1.0.0",
@@ -1871,15 +1871,15 @@
                   "from": "jsonpointer@2.0.0",
                   "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                 },
-                "lodash._basetostring": {
-                  "version": "3.0.1",
-                  "from": "lodash._basetostring@^3.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
-                },
                 "jsprim": {
                   "version": "1.2.2",
                   "from": "jsprim@^1.2.2",
                   "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.1",
+                  "from": "lodash._basetostring@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
                 },
                 "lodash._createpadding": {
                   "version": "3.6.1",
@@ -1996,15 +1996,15 @@
                   "from": "stringstream@~0.0.4",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                 },
-                "strip-json-comments": {
-                  "version": "1.0.4",
-                  "from": "strip-json-comments@~1.0.4",
-                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-                },
                 "strip-ansi": {
                   "version": "3.0.0",
                   "from": "strip-ansi@^3.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+                },
+                "strip-json-comments": {
+                  "version": "1.0.4",
+                  "from": "strip-json-comments@~1.0.4",
+                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
                 },
                 "supports-color": {
                   "version": "2.0.0",
@@ -2263,78 +2263,78 @@
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@>=2.2.0 <3.0.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "es6-promise": {
           "version": "3.1.2",
-          "from": "es6-promise@>=3.0.2 <4.0.0",
+          "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.1.2.tgz",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.1.2.tgz"
         },
         "lodash.defaults": {
           "version": "3.1.2",
-          "from": "lodash.defaults@>=3.1.2 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
           "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
           "dependencies": {
             "lodash.assign": {
               "version": "3.2.0",
-              "from": "lodash.assign@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
               "dependencies": {
                 "lodash._baseassign": {
                   "version": "3.2.0",
-                  "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
                   "dependencies": {
                     "lodash._basecopy": {
                       "version": "3.0.1",
-                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
                     }
                   }
                 },
                 "lodash._createassigner": {
                   "version": "3.1.1",
-                  "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
                   "dependencies": {
                     "lodash._bindcallback": {
                       "version": "3.0.1",
-                      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
                     },
                     "lodash._isiterateecall": {
                       "version": "3.0.9",
-                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
                     }
                   }
                 },
                 "lodash.keys": {
                   "version": "3.1.2",
-                  "from": "lodash.keys@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                   "dependencies": {
                     "lodash._getnative": {
                       "version": "3.9.1",
-                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                     },
                     "lodash.isarguments": {
                       "version": "3.0.7",
-                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz"
                     },
                     "lodash.isarray": {
                       "version": "3.0.4",
-                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                     }
                   }
@@ -2343,29 +2343,29 @@
             },
             "lodash.restparam": {
               "version": "3.6.1",
-              "from": "lodash.restparam@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
             }
           }
         },
         "minimatch": {
           "version": "3.0.0",
-          "from": "minimatch@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.3",
-              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.3.0",
-                  "from": "balanced-match@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                 },
                 "concat-map": {
                   "version": "0.0.1",
-                  "from": "concat-map@0.0.1",
+                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
@@ -2374,47 +2374,47 @@
         },
         "ps-tree": {
           "version": "1.0.1",
-          "from": "ps-tree@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.0.1.tgz",
           "dependencies": {
             "event-stream": {
               "version": "3.3.2",
-              "from": "event-stream@>=3.3.0 <3.4.0",
+              "from": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.2.tgz",
               "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.2.tgz",
               "dependencies": {
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@>=2.3.1 <2.4.0",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 },
                 "duplexer": {
                   "version": "0.1.1",
-                  "from": "duplexer@>=0.1.1 <0.2.0",
+                  "from": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
                 },
                 "from": {
                   "version": "0.1.3",
-                  "from": "from@>=0.0.0 <1.0.0",
+                  "from": "https://registry.npmjs.org/from/-/from-0.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
                 },
                 "map-stream": {
                   "version": "0.1.0",
-                  "from": "map-stream@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
                 },
                 "pause-stream": {
                   "version": "0.0.11",
-                  "from": "pause-stream@0.0.11",
+                  "from": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
                   "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
                 },
                 "split": {
                   "version": "0.3.3",
-                  "from": "split@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz"
                 },
                 "stream-combiner": {
                   "version": "0.0.4",
-                  "from": "stream-combiner@>=0.0.4 <0.1.0",
+                  "from": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
                 }
               }
@@ -2423,17 +2423,17 @@
         },
         "touch": {
           "version": "1.0.0",
-          "from": "touch@1.0.0",
+          "from": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz",
           "dependencies": {
             "nopt": {
               "version": "1.0.10",
-              "from": "nopt@>=1.0.10 <1.1.0",
+              "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.7",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
@@ -2442,32 +2442,32 @@
         },
         "undefsafe": {
           "version": "0.0.3",
-          "from": "undefsafe@0.0.3",
+          "from": "https://registry.npmjs.org/undefsafe/-/undefsafe-0.0.3.tgz",
           "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-0.0.3.tgz"
         },
         "update-notifier": {
           "version": "0.5.0",
-          "from": "update-notifier@0.5.0",
+          "from": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.5.0.tgz",
           "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.5.0.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.1.1",
-              "from": "chalk@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.4",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
@@ -2479,7 +2479,7 @@
                 },
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
@@ -2491,85 +2491,85 @@
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "configstore": {
               "version": "1.4.0",
-              "from": "configstore@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz",
               "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "4.1.3",
-                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                 },
                 "mkdirp": {
                   "version": "0.5.1",
-                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "object-assign": {
                   "version": "4.0.1",
-                  "from": "object-assign@>=4.0.1 <5.0.0",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
                 },
                 "os-tmpdir": {
                   "version": "1.0.1",
-                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                 },
                 "osenv": {
                   "version": "0.1.3",
-                  "from": "osenv@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.1",
-                      "from": "os-homedir@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                     }
                   }
                 },
                 "uuid": {
                   "version": "2.0.1",
-                  "from": "uuid@>=2.0.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
                 },
                 "write-file-atomic": {
                   "version": "1.1.4",
-                  "from": "write-file-atomic@>=1.1.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
                   "dependencies": {
                     "imurmurhash": {
                       "version": "0.1.4",
-                      "from": "imurmurhash@>=0.1.4 <0.2.0",
+                      "from": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
                       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
                     },
                     "slide": {
                       "version": "1.1.6",
-                      "from": "slide@>=1.1.5 <2.0.0",
+                      "from": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
                       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
                     }
                   }
                 },
                 "xdg-basedir": {
                   "version": "2.0.0",
-                  "from": "xdg-basedir@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.1",
-                      "from": "os-homedir@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                     }
                   }
@@ -2578,42 +2578,42 @@
             },
             "is-npm": {
               "version": "1.0.0",
-              "from": "is-npm@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
             },
             "latest-version": {
               "version": "1.0.1",
-              "from": "latest-version@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz",
               "dependencies": {
                 "package-json": {
                   "version": "1.2.0",
-                  "from": "package-json@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz",
                   "dependencies": {
                     "got": {
                       "version": "3.3.1",
-                      "from": "got@>=3.2.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/got/-/got-3.3.1.tgz",
                       "resolved": "https://registry.npmjs.org/got/-/got-3.3.1.tgz",
                       "dependencies": {
                         "duplexify": {
                           "version": "3.4.2",
-                          "from": "duplexify@>=3.2.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
                           "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
                           "dependencies": {
                             "end-of-stream": {
                               "version": "1.0.0",
-                              "from": "end-of-stream@1.0.0",
+                              "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
                               "dependencies": {
                                 "once": {
                                   "version": "1.3.3",
-                                  "from": "once@>=1.3.0 <1.4.0",
+                                  "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                                   "dependencies": {
                                     "wrappy": {
                                       "version": "1.0.1",
-                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                                     }
                                   }
@@ -2622,37 +2622,37 @@
                             },
                             "readable-stream": {
                               "version": "2.0.5",
-                              "from": "readable-stream@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.2",
-                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 },
                                 "isarray": {
                                   "version": "0.0.1",
-                                  "from": "isarray@0.0.1",
+                                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                 },
                                 "process-nextick-args": {
                                   "version": "1.0.6",
-                                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                                 },
                                 "string_decoder": {
                                   "version": "0.10.31",
-                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                 },
                                 "util-deprecate": {
                                   "version": "1.0.2",
-                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                                 }
                               }
@@ -2661,96 +2661,96 @@
                         },
                         "infinity-agent": {
                           "version": "2.0.3",
-                          "from": "infinity-agent@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz"
                         },
                         "is-redirect": {
                           "version": "1.0.0",
-                          "from": "is-redirect@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
                         },
                         "is-stream": {
                           "version": "1.0.1",
-                          "from": "is-stream@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
                         },
                         "lowercase-keys": {
                           "version": "1.0.0",
-                          "from": "lowercase-keys@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
                         },
                         "nested-error-stacks": {
                           "version": "1.0.2",
-                          "from": "nested-error-stacks@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.2.tgz",
                           "dependencies": {
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             }
                           }
                         },
                         "object-assign": {
                           "version": "3.0.0",
-                          "from": "object-assign@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                         },
                         "prepend-http": {
                           "version": "1.0.3",
-                          "from": "prepend-http@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz"
                         },
                         "read-all-stream": {
                           "version": "3.1.0",
-                          "from": "read-all-stream@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
                           "dependencies": {
                             "pinkie-promise": {
                               "version": "2.0.0",
-                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.4",
-                                  "from": "pinkie@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                 }
                               }
                             },
                             "readable-stream": {
                               "version": "2.0.5",
-                              "from": "readable-stream@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.2",
-                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 },
                                 "isarray": {
                                   "version": "0.0.1",
-                                  "from": "isarray@0.0.1",
+                                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                 },
                                 "process-nextick-args": {
                                   "version": "1.0.6",
-                                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                                 },
                                 "string_decoder": {
                                   "version": "0.10.31",
-                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                 },
                                 "util-deprecate": {
                                   "version": "1.0.2",
-                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                                 }
                               }
@@ -2759,39 +2759,39 @@
                         },
                         "timed-out": {
                           "version": "2.0.0",
-                          "from": "timed-out@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
                         }
                       }
                     },
                     "registry-url": {
                       "version": "3.0.3",
-                      "from": "registry-url@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz",
                       "dependencies": {
                         "rc": {
                           "version": "1.1.6",
-                          "from": "rc@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
                           "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
                           "dependencies": {
                             "deep-extend": {
                               "version": "0.4.1",
-                              "from": "deep-extend@>=0.4.0 <0.5.0",
+                              "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
                               "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
                             },
                             "ini": {
                               "version": "1.3.4",
-                              "from": "ini@>=1.3.0 <1.4.0",
+                              "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
                               "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                             },
                             "minimist": {
                               "version": "1.2.0",
-                              "from": "minimist@>=1.2.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                             },
                             "strip-json-comments": {
                               "version": "1.0.4",
-                              "from": "strip-json-comments@>=1.0.4 <1.1.0",
+                              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
                             }
                           }
@@ -2804,17 +2804,17 @@
             },
             "repeating": {
               "version": "1.1.3",
-              "from": "repeating@>=1.1.2 <2.0.0",
+              "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
               "dependencies": {
                 "is-finite": {
                   "version": "1.0.1",
-                  "from": "is-finite@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
@@ -2823,24 +2823,24 @@
             },
             "semver-diff": {
               "version": "2.1.0",
-              "from": "semver-diff@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
               "dependencies": {
                 "semver": {
                   "version": "5.1.0",
-                  "from": "semver@>=5.0.3 <6.0.0",
+                  "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                 }
               }
             },
             "string-length": {
               "version": "1.0.1",
-              "from": "string-length@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
               "dependencies": {
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
@@ -2858,8 +2858,20 @@
     },
     "passport-anonymous": {
       "version": "1.0.1",
-      "from": "passport-anonymous@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/passport-anonymous/-/passport-anonymous-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/passport-anonymous/-/passport-anonymous-1.0.1.tgz",
+      "dependencies": {
+        "passport-strategy": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz"
+        }
+      }
+    },
+    "passport-client-certificate": {
+      "version": "0.1.1",
+      "from": "passport-client-certificate@latest",
+      "resolved": "https://registry.npmjs.org/passport-client-certificate/-/passport-client-certificate-0.1.1.tgz",
       "dependencies": {
         "passport-strategy": {
           "version": "1.0.0",
@@ -2870,88 +2882,88 @@
     },
     "passport-http": {
       "version": "0.3.0",
-      "from": "passport-http@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/passport-http/-/passport-http-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/passport-http/-/passport-http-0.3.0.tgz",
       "dependencies": {
         "passport-strategy": {
           "version": "1.0.0",
-          "from": "passport-strategy@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz"
         }
       }
     },
     "passport-http-signature": {
       "version": "1.0.0",
-      "from": "passport-http-signature@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/passport-http-signature/-/passport-http-signature-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/passport-http-signature/-/passport-http-signature-1.0.0.tgz",
       "dependencies": {
         "http-signature": {
           "version": "1.1.1",
-          "from": "http-signature@>=1.0.2 <2.0.0",
+          "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.2.0",
-              "from": "assert-plus@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
             },
             "jsprim": {
               "version": "1.2.2",
-              "from": "jsprim@>=1.2.2 <2.0.0",
+              "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
               "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
               "dependencies": {
                 "extsprintf": {
                   "version": "1.0.2",
-                  "from": "extsprintf@1.0.2",
+                  "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                 },
                 "json-schema": {
                   "version": "0.2.2",
-                  "from": "json-schema@0.2.2",
+                  "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
                 },
                 "verror": {
                   "version": "1.3.6",
-                  "from": "verror@1.3.6",
+                  "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
                   "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                 }
               }
             },
             "sshpk": {
               "version": "1.7.4",
-              "from": "sshpk@>=1.7.0 <2.0.0",
+              "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz",
               "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz",
               "dependencies": {
                 "asn1": {
                   "version": "0.2.3",
-                  "from": "asn1@>=0.2.3 <0.3.0",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                 },
                 "dashdash": {
                   "version": "1.13.0",
-                  "from": "dashdash@>=1.10.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
                   "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
                   "dependencies": {
                     "assert-plus": {
                       "version": "1.0.0",
-                      "from": "assert-plus@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                     }
                   }
                 },
                 "jsbn": {
                   "version": "0.1.0",
-                  "from": "jsbn@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                 },
                 "jodid25519": {
                   "version": "1.0.2",
-                  "from": "jodid25519@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                 },
                 "ecc-jsbn": {
                   "version": "0.1.1",
-                  "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+                  "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                 }
               }
@@ -2960,69 +2972,69 @@
         },
         "passport-strategy": {
           "version": "1.0.0",
-          "from": "passport-strategy@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz"
         }
       }
     },
     "pg": {
       "version": "4.4.6",
-      "from": "pg@>=4.4.1 <5.0.0",
+      "from": "https://registry.npmjs.org/pg/-/pg-4.4.6.tgz",
       "resolved": "https://registry.npmjs.org/pg/-/pg-4.4.6.tgz",
       "dependencies": {
         "buffer-writer": {
           "version": "1.0.1",
-          "from": "buffer-writer@1.0.1",
+          "from": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz"
         },
         "generic-pool": {
           "version": "2.1.1",
-          "from": "generic-pool@2.1.1",
+          "from": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.1.1.tgz",
           "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.1.1.tgz"
         },
         "packet-reader": {
           "version": "0.2.0",
-          "from": "packet-reader@0.2.0",
+          "from": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.2.0.tgz"
         },
         "pg-connection-string": {
           "version": "0.1.3",
-          "from": "pg-connection-string@0.1.3",
+          "from": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
           "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz"
         },
         "pg-types": {
           "version": "1.10.0",
-          "from": "pg-types@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/pg-types/-/pg-types-1.10.0.tgz",
           "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.10.0.tgz",
           "dependencies": {
             "ap": {
               "version": "0.2.0",
-              "from": "ap@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/ap/-/ap-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/ap/-/ap-0.2.0.tgz"
             },
             "postgres-array": {
               "version": "1.0.0",
-              "from": "postgres-array@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.0.tgz"
             },
             "postgres-bytea": {
               "version": "1.0.0",
-              "from": "postgres-bytea@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz"
             },
             "postgres-date": {
               "version": "1.0.1",
-              "from": "postgres-date@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.1.tgz"
             },
             "postgres-interval": {
               "version": "1.0.1",
-              "from": "postgres-interval@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.0.1.tgz",
               "dependencies": {
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <4.1.0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
@@ -3031,17 +3043,17 @@
         },
         "pgpass": {
           "version": "0.0.3",
-          "from": "pgpass@0.0.3",
+          "from": "https://registry.npmjs.org/pgpass/-/pgpass-0.0.3.tgz",
           "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-0.0.3.tgz",
           "dependencies": {
             "split": {
               "version": "0.3.3",
-              "from": "split@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
               "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
               "dependencies": {
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
@@ -3050,124 +3062,124 @@
         },
         "semver": {
           "version": "4.3.6",
-          "from": "semver@>=4.1.0 <5.0.0",
+          "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         }
       }
     },
     "priorityqueuejs": {
       "version": "1.0.0",
-      "from": "priorityqueuejs@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/priorityqueuejs/-/priorityqueuejs-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/priorityqueuejs/-/priorityqueuejs-1.0.0.tgz"
     },
     "sequelize": {
       "version": "3.14.0",
-      "from": "sequelize@3.14.0",
+      "from": "https://registry.npmjs.org/sequelize/-/sequelize-3.14.0.tgz",
       "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-3.14.0.tgz",
       "dependencies": {
         "bluebird": {
           "version": "3.3.1",
-          "from": "bluebird@>=3.0.6 <4.0.0",
+          "from": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz"
         },
         "depd": {
           "version": "1.1.0",
-          "from": "depd@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
         },
         "dottie": {
           "version": "1.1.1",
-          "from": "dottie@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/dottie/-/dottie-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/dottie/-/dottie-1.1.1.tgz"
         },
         "generic-pool": {
           "version": "2.2.1",
-          "from": "generic-pool@2.2.1",
+          "from": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.2.1.tgz",
           "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.2.1.tgz"
         },
         "inflection": {
           "version": "1.8.0",
-          "from": "inflection@>=1.6.0 <2.0.0",
+          "from": "https://registry.npmjs.org/inflection/-/inflection-1.8.0.tgz",
           "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.8.0.tgz"
         },
         "moment-timezone": {
           "version": "0.4.1",
-          "from": "moment-timezone@>=0.4.1 <0.5.0",
+          "from": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.1.tgz",
           "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.1.tgz"
         },
         "node-uuid": {
           "version": "1.4.7",
-          "from": "node-uuid@>=1.4.4 <1.5.0",
+          "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
         },
         "semver": {
           "version": "5.1.0",
-          "from": "semver@>=5.0.1 <6.0.0",
+          "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
         },
         "shimmer": {
           "version": "1.1.0",
-          "from": "shimmer@1.1.0",
+          "from": "https://registry.npmjs.org/shimmer/-/shimmer-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.1.0.tgz"
         },
         "toposort-class": {
           "version": "1.0.1",
-          "from": "toposort-class@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz"
         },
         "validator": {
           "version": "4.9.0",
-          "from": "validator@>=4.0.4 <5.0.0",
+          "from": "https://registry.npmjs.org/validator/-/validator-4.9.0.tgz",
           "resolved": "https://registry.npmjs.org/validator/-/validator-4.9.0.tgz"
         },
         "wellknown": {
           "version": "0.4.1",
-          "from": "wellknown@>=0.4.0 <0.5.0",
+          "from": "https://registry.npmjs.org/wellknown/-/wellknown-0.4.1.tgz",
           "resolved": "https://registry.npmjs.org/wellknown/-/wellknown-0.4.1.tgz",
           "dependencies": {
             "concat-stream": {
               "version": "1.5.1",
-              "from": "concat-stream@>=1.5.0 <1.6.0",
+              "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
               "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "typedarray": {
                   "version": "0.0.6",
-                  "from": "typedarray@>=0.0.5 <0.1.0",
+                  "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 },
                 "readable-stream": {
                   "version": "2.0.5",
-                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
@@ -3176,102 +3188,102 @@
             },
             "minimist": {
               "version": "1.1.3",
-              "from": "minimist@>=1.1.2 <1.2.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
             }
           }
         },
         "wkx": {
           "version": "0.1.0",
-          "from": "wkx@0.1.0",
+          "from": "https://registry.npmjs.org/wkx/-/wkx-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.1.0.tgz"
         }
       }
     },
     "sequelize-cli": {
       "version": "2.3.1",
-      "from": "sequelize-cli@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/sequelize-cli/-/sequelize-cli-2.3.1.tgz",
       "resolved": "https://registry.npmjs.org/sequelize-cli/-/sequelize-cli-2.3.1.tgz",
       "dependencies": {
         "bluebird": {
           "version": "3.3.1",
-          "from": "bluebird@>=3.0.6 <4.0.0",
+          "from": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz"
         },
         "cli-color": {
           "version": "0.3.3",
-          "from": "cli-color@>=0.3.2 <0.4.0",
+          "from": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz",
           "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz",
           "dependencies": {
             "d": {
               "version": "0.1.1",
-              "from": "d@>=0.1.1 <0.2.0",
+              "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
             },
             "es5-ext": {
               "version": "0.10.11",
-              "from": "es5-ext@>=0.10.6 <0.11.0",
+              "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
               "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
               "dependencies": {
                 "es6-iterator": {
                   "version": "2.0.0",
-                  "from": "es6-iterator@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
                 },
                 "es6-symbol": {
                   "version": "3.0.2",
-                  "from": "es6-symbol@>=3.0.2 <3.1.0",
+                  "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
                 }
               }
             },
             "memoizee": {
               "version": "0.3.9",
-              "from": "memoizee@>=0.3.8 <0.4.0",
+              "from": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.9.tgz",
               "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.9.tgz",
               "dependencies": {
                 "es6-weak-map": {
                   "version": "0.1.4",
-                  "from": "es6-weak-map@>=0.1.4 <0.2.0",
+                  "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
                   "dependencies": {
                     "es6-iterator": {
                       "version": "0.1.3",
-                      "from": "es6-iterator@>=0.1.3 <0.2.0",
+                      "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
                     },
                     "es6-symbol": {
                       "version": "2.0.1",
-                      "from": "es6-symbol@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                     }
                   }
                 },
                 "event-emitter": {
                   "version": "0.3.4",
-                  "from": "event-emitter@>=0.3.3 <0.4.0",
+                  "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
                   "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
                 },
                 "lru-queue": {
                   "version": "0.1.0",
-                  "from": "lru-queue@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
                 },
                 "next-tick": {
                   "version": "0.2.2",
-                  "from": "next-tick@>=0.2.2 <0.3.0",
+                  "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
                 }
               }
             },
             "timers-ext": {
               "version": "0.1.0",
-              "from": "timers-ext@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
               "dependencies": {
                 "next-tick": {
                   "version": "0.2.2",
-                  "from": "next-tick@>=0.2.2 <0.3.0",
+                  "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
                 }
               }
@@ -3280,49 +3292,49 @@
         },
         "findup-sync": {
           "version": "0.3.0",
-          "from": "findup-sync@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
           "dependencies": {
             "glob": {
               "version": "5.0.15",
-              "from": "glob@>=5.0.0 <5.1.0",
+              "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "3.0.0",
-                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.3",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.3.0",
-                          "from": "balanced-match@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -3331,19 +3343,19 @@
                 },
                 "once": {
                   "version": "1.3.3",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 }
               }
@@ -3352,74 +3364,74 @@
         },
         "fs-extra": {
           "version": "0.26.5",
-          "from": "fs-extra@>=0.26.3 <0.27.0",
+          "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.5.tgz",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.5.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "4.1.3",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
             },
             "jsonfile": {
               "version": "2.2.3",
-              "from": "jsonfile@>=2.1.0 <3.0.0",
+              "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz",
               "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz"
             },
             "klaw": {
               "version": "1.1.3",
-              "from": "klaw@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/klaw/-/klaw-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.1.3.tgz"
             },
             "path-is-absolute": {
               "version": "1.0.0",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             },
             "rimraf": {
               "version": "2.5.2",
-              "from": "rimraf@>=2.2.8 <3.0.0",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
               "dependencies": {
                 "glob": {
                   "version": "7.0.0",
-                  "from": "glob@>=7.0.0 <8.0.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-7.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.0.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "3.0.0",
-                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.3",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -3428,12 +3440,12 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -3446,198 +3458,198 @@
         },
         "gulp": {
           "version": "3.9.1",
-          "from": "gulp@>=3.8.10 <4.0.0",
+          "from": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
           "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
           "dependencies": {
             "archy": {
               "version": "1.0.0",
-              "from": "archy@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
             },
             "chalk": {
               "version": "1.1.1",
-              "from": "chalk@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.4",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "deprecated": {
               "version": "0.0.1",
-              "from": "deprecated@>=0.0.1 <0.0.2",
+              "from": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz"
             },
             "gulp-util": {
               "version": "3.0.7",
-              "from": "gulp-util@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
               "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
               "dependencies": {
                 "array-differ": {
                   "version": "1.0.0",
-                  "from": "array-differ@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
                 },
                 "array-uniq": {
                   "version": "1.0.2",
-                  "from": "array-uniq@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
                 },
                 "beeper": {
                   "version": "1.1.0",
-                  "from": "beeper@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
                 },
                 "dateformat": {
                   "version": "1.0.12",
-                  "from": "dateformat@>=1.0.11 <2.0.0",
+                  "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
                   "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
                   "dependencies": {
                     "get-stdin": {
                       "version": "4.0.1",
-                      "from": "get-stdin@>=4.0.1 <5.0.0",
+                      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                     },
                     "meow": {
                       "version": "3.7.0",
-                      "from": "meow@>=3.3.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
                       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
                       "dependencies": {
                         "camelcase-keys": {
                           "version": "2.0.0",
-                          "from": "camelcase-keys@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
                           "dependencies": {
                             "camelcase": {
                               "version": "2.1.0",
-                              "from": "camelcase@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
                             }
                           }
                         },
                         "decamelize": {
                           "version": "1.1.2",
-                          "from": "decamelize@>=1.1.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
                           "dependencies": {
                             "escape-string-regexp": {
                               "version": "1.0.4",
-                              "from": "escape-string-regexp@>=1.0.4 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                             }
                           }
                         },
                         "loud-rejection": {
                           "version": "1.3.0",
-                          "from": "loud-rejection@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
                           "dependencies": {
                             "array-find-index": {
                               "version": "1.0.1",
-                              "from": "array-find-index@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
                             },
                             "signal-exit": {
                               "version": "2.1.2",
-                              "from": "signal-exit@>=2.1.2 <3.0.0",
+                              "from": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
                               "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
                             }
                           }
                         },
                         "map-obj": {
                           "version": "1.0.1",
-                          "from": "map-obj@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                         },
                         "normalize-package-data": {
                           "version": "2.3.5",
-                          "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                          "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                           "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                           "dependencies": {
                             "hosted-git-info": {
                               "version": "2.1.4",
-                              "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                              "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
                               "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
                             },
                             "is-builtin-module": {
                               "version": "1.0.0",
-                              "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                               "dependencies": {
                                 "builtin-modules": {
                                   "version": "1.1.1",
-                                  "from": "builtin-modules@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
                                   "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
                                 }
                               }
                             },
                             "validate-npm-package-license": {
                               "version": "3.0.1",
-                              "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                              "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                               "dependencies": {
                                 "spdx-correct": {
                                   "version": "1.0.2",
-                                  "from": "spdx-correct@>=1.0.0 <1.1.0",
+                                  "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                                   "dependencies": {
                                     "spdx-license-ids": {
                                       "version": "1.2.0",
-                                      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                      "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
                                       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
                                     }
                                   }
                                 },
                                 "spdx-expression-parse": {
                                   "version": "1.0.2",
-                                  "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                                  "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                                   "dependencies": {
                                     "spdx-exceptions": {
                                       "version": "1.0.4",
-                                      "from": "spdx-exceptions@>=1.0.4 <2.0.0",
+                                      "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
                                       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
                                     },
                                     "spdx-license-ids": {
                                       "version": "1.2.0",
-                                      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                      "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
                                       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
                                     }
                                   }
@@ -3648,32 +3660,32 @@
                         },
                         "object-assign": {
                           "version": "4.0.1",
-                          "from": "object-assign@>=4.0.1 <5.0.0",
+                          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
                         },
                         "read-pkg-up": {
                           "version": "1.0.1",
-                          "from": "read-pkg-up@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                           "dependencies": {
                             "find-up": {
                               "version": "1.1.0",
-                              "from": "find-up@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
                               "dependencies": {
                                 "path-exists": {
                                   "version": "2.1.0",
-                                  "from": "path-exists@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                                 },
                                 "pinkie-promise": {
                                   "version": "2.0.0",
-                                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "2.0.4",
-                                      "from": "pinkie@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                     }
                                   }
@@ -3682,32 +3694,32 @@
                             },
                             "read-pkg": {
                               "version": "1.1.0",
-                              "from": "read-pkg@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                               "dependencies": {
                                 "load-json-file": {
                                   "version": "1.1.0",
-                                  "from": "load-json-file@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                                   "dependencies": {
                                     "graceful-fs": {
                                       "version": "4.1.3",
-                                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
                                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                                     },
                                     "parse-json": {
                                       "version": "2.2.0",
-                                      "from": "parse-json@>=2.2.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                                       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                                       "dependencies": {
                                         "error-ex": {
                                           "version": "1.3.0",
-                                          "from": "error-ex@>=1.2.0 <2.0.0",
+                                          "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                                           "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                                           "dependencies": {
                                             "is-arrayish": {
                                               "version": "0.2.1",
-                                              "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                              "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
                                               "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
                                             }
                                           }
@@ -3716,29 +3728,29 @@
                                     },
                                     "pify": {
                                       "version": "2.3.0",
-                                      "from": "pify@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                                       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                     },
                                     "pinkie-promise": {
                                       "version": "2.0.0",
-                                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                                       "dependencies": {
                                         "pinkie": {
                                           "version": "2.0.4",
-                                          "from": "pinkie@>=2.0.0 <3.0.0",
+                                          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                                           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                         }
                                       }
                                     },
                                     "strip-bom": {
                                       "version": "2.0.0",
-                                      "from": "strip-bom@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                                       "dependencies": {
                                         "is-utf8": {
                                           "version": "0.2.1",
-                                          "from": "is-utf8@>=0.2.0 <0.3.0",
+                                          "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
                                           "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
                                         }
                                       }
@@ -3747,27 +3759,27 @@
                                 },
                                 "path-type": {
                                   "version": "1.1.0",
-                                  "from": "path-type@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                                   "dependencies": {
                                     "graceful-fs": {
                                       "version": "4.1.3",
-                                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
                                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                                     },
                                     "pify": {
                                       "version": "2.3.0",
-                                      "from": "pify@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                                       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                     },
                                     "pinkie-promise": {
                                       "version": "2.0.0",
-                                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                                       "dependencies": {
                                         "pinkie": {
                                           "version": "2.0.4",
-                                          "from": "pinkie@>=2.0.0 <3.0.0",
+                                          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                                           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                         }
                                       }
@@ -3780,27 +3792,27 @@
                         },
                         "redent": {
                           "version": "1.0.0",
-                          "from": "redent@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                           "dependencies": {
                             "indent-string": {
                               "version": "2.1.0",
-                              "from": "indent-string@>=2.1.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                               "dependencies": {
                                 "repeating": {
                                   "version": "2.0.0",
-                                  "from": "repeating@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                                   "dependencies": {
                                     "is-finite": {
                                       "version": "1.0.1",
-                                      "from": "is-finite@>=1.0.0 <2.0.0",
+                                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                                       "dependencies": {
                                         "number-is-nan": {
                                           "version": "1.0.0",
-                                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                                           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                         }
                                       }
@@ -3811,14 +3823,14 @@
                             },
                             "strip-indent": {
                               "version": "1.0.1",
-                              "from": "strip-indent@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
                             }
                           }
                         },
                         "trim-newlines": {
                           "version": "1.0.0",
-                          "from": "trim-newlines@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
                         }
                       }
@@ -3827,29 +3839,29 @@
                 },
                 "fancy-log": {
                   "version": "1.2.0",
-                  "from": "fancy-log@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
                   "dependencies": {
                     "time-stamp": {
                       "version": "1.0.0",
-                      "from": "time-stamp@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.0.tgz"
                     }
                   }
                 },
                 "gulplog": {
                   "version": "1.0.0",
-                  "from": "gulplog@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
                   "dependencies": {
                     "glogg": {
                       "version": "1.0.0",
-                      "from": "glogg@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
                       "dependencies": {
                         "sparkles": {
                           "version": "1.0.0",
-                          "from": "sparkles@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
                         }
                       }
@@ -3858,135 +3870,135 @@
                 },
                 "has-gulplog": {
                   "version": "0.1.0",
-                  "from": "has-gulplog@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
                   "dependencies": {
                     "sparkles": {
                       "version": "1.0.0",
-                      "from": "sparkles@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
                     }
                   }
                 },
                 "lodash._reescape": {
                   "version": "3.0.0",
-                  "from": "lodash._reescape@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
                 },
                 "lodash._reevaluate": {
                   "version": "3.0.0",
-                  "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
                 },
                 "lodash._reinterpolate": {
                   "version": "3.0.0",
-                  "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
                 },
                 "lodash.template": {
                   "version": "3.6.2",
-                  "from": "lodash.template@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
                   "dependencies": {
                     "lodash._basecopy": {
                       "version": "3.0.1",
-                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
                     },
                     "lodash._basetostring": {
                       "version": "3.0.1",
-                      "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
                     },
                     "lodash._basevalues": {
                       "version": "3.0.0",
-                      "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
                     },
                     "lodash._isiterateecall": {
                       "version": "3.0.9",
-                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
                     },
                     "lodash.escape": {
                       "version": "3.2.0",
-                      "from": "lodash.escape@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
                       "dependencies": {
                         "lodash._root": {
                           "version": "3.0.1",
-                          "from": "lodash._root@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
                         }
                       }
                     },
                     "lodash.keys": {
                       "version": "3.1.2",
-                      "from": "lodash.keys@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                       "dependencies": {
                         "lodash._getnative": {
                           "version": "3.9.1",
-                          "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
                           "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                         },
                         "lodash.isarguments": {
                           "version": "3.0.7",
-                          "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz",
                           "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz"
                         },
                         "lodash.isarray": {
                           "version": "3.0.4",
-                          "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                         }
                       }
                     },
                     "lodash.restparam": {
                       "version": "3.6.1",
-                      "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
                     },
                     "lodash.templatesettings": {
                       "version": "3.1.1",
-                      "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
                     }
                   }
                 },
                 "multipipe": {
                   "version": "0.1.2",
-                  "from": "multipipe@>=0.1.2 <0.2.0",
+                  "from": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
                   "dependencies": {
                     "duplexer2": {
                       "version": "0.0.2",
-                      "from": "duplexer2@0.0.2",
+                      "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                       "dependencies": {
                         "readable-stream": {
                           "version": "1.1.13",
-                          "from": "readable-stream@>=1.1.9 <1.2.0",
+                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "isarray@0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             }
                           }
@@ -3997,76 +4009,76 @@
                 },
                 "object-assign": {
                   "version": "3.0.0",
-                  "from": "object-assign@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                 },
                 "replace-ext": {
                   "version": "0.0.1",
-                  "from": "replace-ext@0.0.1",
+                  "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
                 },
                 "through2": {
                   "version": "2.0.1",
-                  "from": "through2@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "2.0.5",
-                      "from": "readable-stream@>=2.0.0 <2.1.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "process-nextick-args": {
                           "version": "1.0.6",
-                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         }
                       }
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "from": "xtend@>=4.0.0 <4.1.0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
                 "vinyl": {
                   "version": "0.5.3",
-                  "from": "vinyl@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
                   "dependencies": {
                     "clone": {
                       "version": "1.0.2",
-                      "from": "clone@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
                     },
                     "clone-stats": {
                       "version": "0.0.1",
-                      "from": "clone-stats@>=0.0.1 <0.0.2",
+                      "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
                     }
                   }
@@ -4075,54 +4087,54 @@
             },
             "interpret": {
               "version": "1.0.0",
-              "from": "interpret@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/interpret/-/interpret-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.0.tgz"
             },
             "liftoff": {
               "version": "2.2.0",
-              "from": "liftoff@>=2.1.0 <3.0.0",
+              "from": "https://registry.npmjs.org/liftoff/-/liftoff-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.2.0.tgz",
               "dependencies": {
                 "extend": {
                   "version": "2.0.1",
-                  "from": "extend@>=2.0.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
                 },
                 "flagged-respawn": {
                   "version": "0.3.1",
-                  "from": "flagged-respawn@>=0.3.1 <0.4.0",
+                  "from": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz"
                 },
                 "rechoir": {
                   "version": "0.6.2",
-                  "from": "rechoir@>=0.6.0 <0.7.0",
+                  "from": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
                   "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
                 }
               }
             },
             "minimist": {
               "version": "1.2.0",
-              "from": "minimist@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
             },
             "orchestrator": {
               "version": "0.3.7",
-              "from": "orchestrator@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
               "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
               "dependencies": {
                 "end-of-stream": {
                   "version": "0.1.5",
-                  "from": "end-of-stream@>=0.1.5 <0.2.0",
+                  "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
                   "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
                   "dependencies": {
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <1.4.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -4131,102 +4143,102 @@
                 },
                 "sequencify": {
                   "version": "0.0.7",
-                  "from": "sequencify@>=0.0.7 <0.1.0",
+                  "from": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz"
                 },
                 "stream-consume": {
                   "version": "0.1.0",
-                  "from": "stream-consume@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
                 }
               }
             },
             "pretty-hrtime": {
               "version": "1.0.2",
-              "from": "pretty-hrtime@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.2.tgz"
             },
             "semver": {
               "version": "4.3.6",
-              "from": "semver@>=4.1.0 <5.0.0",
+              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
             },
             "tildify": {
               "version": "1.1.2",
-              "from": "tildify@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/tildify/-/tildify-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.1.2.tgz",
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.1",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
                 }
               }
             },
             "v8flags": {
               "version": "2.0.11",
-              "from": "v8flags@>=2.0.2 <3.0.0",
+              "from": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz",
               "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz",
               "dependencies": {
                 "user-home": {
                   "version": "1.1.1",
-                  "from": "user-home@>=1.1.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
                 }
               }
             },
             "vinyl-fs": {
               "version": "0.3.14",
-              "from": "vinyl-fs@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
               "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
               "dependencies": {
                 "defaults": {
                   "version": "1.0.3",
-                  "from": "defaults@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
                   "dependencies": {
                     "clone": {
                       "version": "1.0.2",
-                      "from": "clone@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
                     }
                   }
                 },
                 "glob-stream": {
                   "version": "3.1.18",
-                  "from": "glob-stream@>=3.1.5 <4.0.0",
+                  "from": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
                   "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
                   "dependencies": {
                     "glob": {
                       "version": "4.5.3",
-                      "from": "glob@>=4.3.1 <5.0.0",
+                      "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                       "dependencies": {
                         "inflight": {
                           "version": "1.0.4",
-                          "from": "inflight@>=1.0.4 <2.0.0",
+                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                             }
                           }
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "once": {
                           "version": "1.3.3",
-                          "from": "once@>=1.3.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                             }
                           }
@@ -4235,22 +4247,22 @@
                     },
                     "minimatch": {
                       "version": "2.0.10",
-                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.3",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -4259,78 +4271,78 @@
                     },
                     "ordered-read-streams": {
                       "version": "0.1.0",
-                      "from": "ordered-read-streams@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
                     },
                     "glob2base": {
                       "version": "0.0.12",
-                      "from": "glob2base@>=0.0.12 <0.0.13",
+                      "from": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
                       "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
                       "dependencies": {
                         "find-index": {
                           "version": "0.1.1",
-                          "from": "find-index@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
                         }
                       }
                     },
                     "unique-stream": {
                       "version": "1.0.0",
-                      "from": "unique-stream@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
                     }
                   }
                 },
                 "glob-watcher": {
                   "version": "0.0.6",
-                  "from": "glob-watcher@>=0.0.6 <0.0.7",
+                  "from": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
                   "dependencies": {
                     "gaze": {
                       "version": "0.5.2",
-                      "from": "gaze@>=0.5.1 <0.6.0",
+                      "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
                       "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
                       "dependencies": {
                         "globule": {
                           "version": "0.1.0",
-                          "from": "globule@>=0.1.0 <0.2.0",
+                          "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
                           "dependencies": {
                             "lodash": {
                               "version": "1.0.2",
-                              "from": "lodash@>=1.0.1 <1.1.0",
+                              "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
                             },
                             "glob": {
                               "version": "3.1.21",
-                              "from": "glob@>=3.1.21 <3.2.0",
+                              "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                               "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                               "dependencies": {
                                 "graceful-fs": {
                                   "version": "1.2.3",
-                                  "from": "graceful-fs@>=1.2.0 <1.3.0",
+                                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
                                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                                 },
                                 "inherits": {
                                   "version": "1.0.2",
-                                  "from": "inherits@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
                                 }
                               }
                             },
                             "minimatch": {
                               "version": "0.2.14",
-                              "from": "minimatch@>=0.2.11 <0.3.0",
+                              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                               "dependencies": {
                                 "lru-cache": {
                                   "version": "2.7.3",
-                                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
                                   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                                 },
                                 "sigmund": {
                                   "version": "1.0.1",
-                                  "from": "sigmund@>=1.0.0 <1.1.0",
+                                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                                 }
                               }
@@ -4343,90 +4355,90 @@
                 },
                 "graceful-fs": {
                   "version": "3.0.8",
-                  "from": "graceful-fs@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
                 },
                 "mkdirp": {
                   "version": "0.5.1",
-                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "strip-bom": {
                   "version": "1.0.0",
-                  "from": "strip-bom@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
                   "dependencies": {
                     "first-chunk-stream": {
                       "version": "1.0.0",
-                      "from": "first-chunk-stream@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
                     },
                     "is-utf8": {
                       "version": "0.2.1",
-                      "from": "is-utf8@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
                     }
                   }
                 },
                 "through2": {
                   "version": "0.6.5",
-                  "from": "through2@>=0.6.1 <0.7.0",
+                  "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.0.33",
-                      "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "from": "xtend@>=4.0.0 <4.1.0-0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
                 "vinyl": {
                   "version": "0.4.6",
-                  "from": "vinyl@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
                   "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
                   "dependencies": {
                     "clone": {
                       "version": "0.2.0",
-                      "from": "clone@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
                     },
                     "clone-stats": {
                       "version": "0.0.1",
-                      "from": "clone-stats@>=0.0.1 <0.0.2",
+                      "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
                     }
                   }
@@ -4437,193 +4449,193 @@
         },
         "gulp-help": {
           "version": "1.3.4",
-          "from": "gulp-help@>=1.3.1 <1.4.0",
+          "from": "https://registry.npmjs.org/gulp-help/-/gulp-help-1.3.4.tgz",
           "resolved": "https://registry.npmjs.org/gulp-help/-/gulp-help-1.3.4.tgz",
           "dependencies": {
             "gulp-util": {
               "version": "3.0.7",
-              "from": "gulp-util@>=3.0.4 <4.0.0",
+              "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
               "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
               "dependencies": {
                 "array-differ": {
                   "version": "1.0.0",
-                  "from": "array-differ@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
                 },
                 "array-uniq": {
                   "version": "1.0.2",
-                  "from": "array-uniq@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
                 },
                 "beeper": {
                   "version": "1.1.0",
-                  "from": "beeper@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
                 },
                 "chalk": {
                   "version": "1.1.1",
-                  "from": "chalk@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.1.0",
-                      "from": "ansi-styles@>=2.1.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                     },
                     "escape-string-regexp": {
                       "version": "1.0.4",
-                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                     },
                     "has-ansi": {
                       "version": "2.0.0",
-                      "from": "has-ansi@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "3.0.0",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "supports-color": {
                       "version": "2.0.0",
-                      "from": "supports-color@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                     }
                   }
                 },
                 "dateformat": {
                   "version": "1.0.12",
-                  "from": "dateformat@>=1.0.11 <2.0.0",
+                  "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
                   "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
                   "dependencies": {
                     "get-stdin": {
                       "version": "4.0.1",
-                      "from": "get-stdin@>=4.0.1 <5.0.0",
+                      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                     },
                     "meow": {
                       "version": "3.7.0",
-                      "from": "meow@>=3.3.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
                       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
                       "dependencies": {
                         "camelcase-keys": {
                           "version": "2.0.0",
-                          "from": "camelcase-keys@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
                           "dependencies": {
                             "camelcase": {
                               "version": "2.1.0",
-                              "from": "camelcase@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
                             }
                           }
                         },
                         "decamelize": {
                           "version": "1.1.2",
-                          "from": "decamelize@>=1.1.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
                           "dependencies": {
                             "escape-string-regexp": {
                               "version": "1.0.4",
-                              "from": "escape-string-regexp@>=1.0.4 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                             }
                           }
                         },
                         "loud-rejection": {
                           "version": "1.3.0",
-                          "from": "loud-rejection@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
                           "dependencies": {
                             "array-find-index": {
                               "version": "1.0.1",
-                              "from": "array-find-index@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
                             },
                             "signal-exit": {
                               "version": "2.1.2",
-                              "from": "signal-exit@>=2.1.2 <3.0.0",
+                              "from": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
                               "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
                             }
                           }
                         },
                         "map-obj": {
                           "version": "1.0.1",
-                          "from": "map-obj@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                         },
                         "normalize-package-data": {
                           "version": "2.3.5",
-                          "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                          "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                           "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                           "dependencies": {
                             "hosted-git-info": {
                               "version": "2.1.4",
-                              "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                              "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
                               "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
                             },
                             "is-builtin-module": {
                               "version": "1.0.0",
-                              "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                               "dependencies": {
                                 "builtin-modules": {
                                   "version": "1.1.1",
-                                  "from": "builtin-modules@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
                                   "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
                                 }
                               }
                             },
                             "semver": {
                               "version": "5.1.0",
-                              "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+                              "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                             },
                             "validate-npm-package-license": {
                               "version": "3.0.1",
-                              "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                              "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                               "dependencies": {
                                 "spdx-correct": {
                                   "version": "1.0.2",
-                                  "from": "spdx-correct@>=1.0.0 <1.1.0",
+                                  "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                                   "dependencies": {
                                     "spdx-license-ids": {
                                       "version": "1.2.0",
-                                      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                      "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
                                       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
                                     }
                                   }
                                 },
                                 "spdx-expression-parse": {
                                   "version": "1.0.2",
-                                  "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                                  "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                                   "dependencies": {
                                     "spdx-exceptions": {
                                       "version": "1.0.4",
-                                      "from": "spdx-exceptions@>=1.0.4 <2.0.0",
+                                      "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
                                       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
                                     },
                                     "spdx-license-ids": {
                                       "version": "1.2.0",
-                                      "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                                      "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
                                       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
                                     }
                                   }
@@ -4634,32 +4646,32 @@
                         },
                         "object-assign": {
                           "version": "4.0.1",
-                          "from": "object-assign@>=4.0.1 <5.0.0",
+                          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
                         },
                         "read-pkg-up": {
                           "version": "1.0.1",
-                          "from": "read-pkg-up@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                           "dependencies": {
                             "find-up": {
                               "version": "1.1.0",
-                              "from": "find-up@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
                               "dependencies": {
                                 "path-exists": {
                                   "version": "2.1.0",
-                                  "from": "path-exists@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                                 },
                                 "pinkie-promise": {
                                   "version": "2.0.0",
-                                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "2.0.4",
-                                      "from": "pinkie@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                     }
                                   }
@@ -4668,32 +4680,32 @@
                             },
                             "read-pkg": {
                               "version": "1.1.0",
-                              "from": "read-pkg@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                               "dependencies": {
                                 "load-json-file": {
                                   "version": "1.1.0",
-                                  "from": "load-json-file@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                                   "dependencies": {
                                     "graceful-fs": {
                                       "version": "4.1.3",
-                                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
                                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                                     },
                                     "parse-json": {
                                       "version": "2.2.0",
-                                      "from": "parse-json@>=2.2.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                                       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                                       "dependencies": {
                                         "error-ex": {
                                           "version": "1.3.0",
-                                          "from": "error-ex@>=1.2.0 <2.0.0",
+                                          "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                                           "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                                           "dependencies": {
                                             "is-arrayish": {
                                               "version": "0.2.1",
-                                              "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                              "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
                                               "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
                                             }
                                           }
@@ -4702,29 +4714,29 @@
                                     },
                                     "pify": {
                                       "version": "2.3.0",
-                                      "from": "pify@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                                       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                     },
                                     "pinkie-promise": {
                                       "version": "2.0.0",
-                                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                                       "dependencies": {
                                         "pinkie": {
                                           "version": "2.0.4",
-                                          "from": "pinkie@>=2.0.0 <3.0.0",
+                                          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                                           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                         }
                                       }
                                     },
                                     "strip-bom": {
                                       "version": "2.0.0",
-                                      "from": "strip-bom@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                                       "dependencies": {
                                         "is-utf8": {
                                           "version": "0.2.1",
-                                          "from": "is-utf8@>=0.2.0 <0.3.0",
+                                          "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
                                           "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
                                         }
                                       }
@@ -4733,27 +4745,27 @@
                                 },
                                 "path-type": {
                                   "version": "1.1.0",
-                                  "from": "path-type@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                                   "dependencies": {
                                     "graceful-fs": {
                                       "version": "4.1.3",
-                                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
                                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                                     },
                                     "pify": {
                                       "version": "2.3.0",
-                                      "from": "pify@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                                       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                     },
                                     "pinkie-promise": {
                                       "version": "2.0.0",
-                                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                                       "dependencies": {
                                         "pinkie": {
                                           "version": "2.0.4",
-                                          "from": "pinkie@>=2.0.0 <3.0.0",
+                                          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                                           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                         }
                                       }
@@ -4766,27 +4778,27 @@
                         },
                         "redent": {
                           "version": "1.0.0",
-                          "from": "redent@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                           "dependencies": {
                             "indent-string": {
                               "version": "2.1.0",
-                              "from": "indent-string@>=2.1.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                               "dependencies": {
                                 "repeating": {
                                   "version": "2.0.0",
-                                  "from": "repeating@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                                   "dependencies": {
                                     "is-finite": {
                                       "version": "1.0.1",
-                                      "from": "is-finite@>=1.0.0 <2.0.0",
+                                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                                       "dependencies": {
                                         "number-is-nan": {
                                           "version": "1.0.0",
-                                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                                           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                         }
                                       }
@@ -4797,14 +4809,14 @@
                             },
                             "strip-indent": {
                               "version": "1.0.1",
-                              "from": "strip-indent@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
                             }
                           }
                         },
                         "trim-newlines": {
                           "version": "1.0.0",
-                          "from": "trim-newlines@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
                         }
                       }
@@ -4813,29 +4825,29 @@
                 },
                 "fancy-log": {
                   "version": "1.2.0",
-                  "from": "fancy-log@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz",
                   "dependencies": {
                     "time-stamp": {
                       "version": "1.0.0",
-                      "from": "time-stamp@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.0.tgz"
                     }
                   }
                 },
                 "gulplog": {
                   "version": "1.0.0",
-                  "from": "gulplog@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
                   "dependencies": {
                     "glogg": {
                       "version": "1.0.0",
-                      "from": "glogg@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
                       "dependencies": {
                         "sparkles": {
                           "version": "1.0.0",
-                          "from": "sparkles@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
                         }
                       }
@@ -4844,140 +4856,140 @@
                 },
                 "has-gulplog": {
                   "version": "0.1.0",
-                  "from": "has-gulplog@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
                   "dependencies": {
                     "sparkles": {
                       "version": "1.0.0",
-                      "from": "sparkles@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
                     }
                   }
                 },
                 "lodash._reescape": {
                   "version": "3.0.0",
-                  "from": "lodash._reescape@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
                 },
                 "lodash._reevaluate": {
                   "version": "3.0.0",
-                  "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
                 },
                 "lodash._reinterpolate": {
                   "version": "3.0.0",
-                  "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
                 },
                 "lodash.template": {
                   "version": "3.6.2",
-                  "from": "lodash.template@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
                   "dependencies": {
                     "lodash._basecopy": {
                       "version": "3.0.1",
-                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
                     },
                     "lodash._basetostring": {
                       "version": "3.0.1",
-                      "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
                     },
                     "lodash._basevalues": {
                       "version": "3.0.0",
-                      "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
                     },
                     "lodash._isiterateecall": {
                       "version": "3.0.9",
-                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
                     },
                     "lodash.escape": {
                       "version": "3.2.0",
-                      "from": "lodash.escape@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
                       "dependencies": {
                         "lodash._root": {
                           "version": "3.0.1",
-                          "from": "lodash._root@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
                         }
                       }
                     },
                     "lodash.keys": {
                       "version": "3.1.2",
-                      "from": "lodash.keys@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                       "dependencies": {
                         "lodash._getnative": {
                           "version": "3.9.1",
-                          "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
                           "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                         },
                         "lodash.isarguments": {
                           "version": "3.0.7",
-                          "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz",
                           "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz"
                         },
                         "lodash.isarray": {
                           "version": "3.0.4",
-                          "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                         }
                       }
                     },
                     "lodash.restparam": {
                       "version": "3.6.1",
-                      "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
                     },
                     "lodash.templatesettings": {
                       "version": "3.1.1",
-                      "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
                     }
                   }
                 },
                 "minimist": {
                   "version": "1.2.0",
-                  "from": "minimist@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 },
                 "multipipe": {
                   "version": "0.1.2",
-                  "from": "multipipe@>=0.1.2 <0.2.0",
+                  "from": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
                   "dependencies": {
                     "duplexer2": {
                       "version": "0.0.2",
-                      "from": "duplexer2@0.0.2",
+                      "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                       "dependencies": {
                         "readable-stream": {
                           "version": "1.1.13",
-                          "from": "readable-stream@>=1.1.9 <1.2.0",
+                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "isarray@0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             }
                           }
@@ -4988,76 +5000,76 @@
                 },
                 "object-assign": {
                   "version": "3.0.0",
-                  "from": "object-assign@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                 },
                 "replace-ext": {
                   "version": "0.0.1",
-                  "from": "replace-ext@0.0.1",
+                  "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
                 },
                 "through2": {
                   "version": "2.0.1",
-                  "from": "through2@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "2.0.5",
-                      "from": "readable-stream@>=2.0.0 <2.1.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "process-nextick-args": {
                           "version": "1.0.6",
-                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         }
                       }
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "from": "xtend@>=4.0.0 <4.1.0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
                 "vinyl": {
                   "version": "0.5.3",
-                  "from": "vinyl@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
                   "dependencies": {
                     "clone": {
                       "version": "1.0.2",
-                      "from": "clone@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
                     },
                     "clone-stats": {
                       "version": "0.0.1",
-                      "from": "clone-stats@>=0.0.1 <0.0.2",
+                      "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
                     }
                   }
@@ -5066,53 +5078,53 @@
             },
             "lodash": {
               "version": "3.10.1",
-              "from": "lodash@>=3.5.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
             }
           }
         },
         "js-beautify": {
           "version": "1.6.2",
-          "from": "js-beautify@>=1.5.4 <2.0.0",
+          "from": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.2.tgz",
           "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.2.tgz",
           "dependencies": {
             "config-chain": {
               "version": "1.1.10",
-              "from": "config-chain@>=1.1.5 <1.2.0",
+              "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
               "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
               "dependencies": {
                 "proto-list": {
                   "version": "1.2.4",
-                  "from": "proto-list@>=1.2.1 <1.3.0",
+                  "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
                   "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
                 },
                 "ini": {
                   "version": "1.3.4",
-                  "from": "ini@>=1.3.4 <2.0.0",
+                  "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
                   "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                 }
               }
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "nopt": {
               "version": "3.0.6",
-              "from": "nopt@>=3.0.1 <3.1.0",
+              "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
               "dependencies": {
                 "abbrev": {
                   "version": "1.0.7",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
                 }
               }
@@ -5121,73 +5133,73 @@
         },
         "lodash": {
           "version": "4.5.0",
-          "from": "lodash@>=4.0.0 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.5.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.5.0.tgz"
         },
         "resolve": {
           "version": "1.1.7",
-          "from": "resolve@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
         },
         "yargs": {
           "version": "3.32.0",
-          "from": "yargs@>=3.30.0 <4.0.0",
+          "from": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
           "dependencies": {
             "camelcase": {
               "version": "2.1.0",
-              "from": "camelcase@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
             },
             "cliui": {
               "version": "3.1.0",
-              "from": "cliui@>=3.0.3 <4.0.0",
+              "from": "https://registry.npmjs.org/cliui/-/cliui-3.1.0.tgz",
               "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.1.0.tgz",
               "dependencies": {
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "wrap-ansi": {
                   "version": "1.0.0",
-                  "from": "wrap-ansi@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-1.0.0.tgz"
                 }
               }
             },
             "decamelize": {
               "version": "1.1.2",
-              "from": "decamelize@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
               "dependencies": {
                 "escape-string-regexp": {
                   "version": "1.0.4",
-                  "from": "escape-string-regexp@>=1.0.4 <2.0.0",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                 }
               }
             },
             "os-locale": {
               "version": "1.4.0",
-              "from": "os-locale@>=1.4.0 <2.0.0",
+              "from": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
               "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
               "dependencies": {
                 "lcid": {
                   "version": "1.0.0",
-                  "from": "lcid@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
                   "dependencies": {
                     "invert-kv": {
                       "version": "1.0.0",
-                      "from": "invert-kv@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
                     }
                   }
@@ -5196,41 +5208,41 @@
             },
             "string-width": {
               "version": "1.0.1",
-              "from": "string-width@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
               "dependencies": {
                 "code-point-at": {
                   "version": "1.0.0",
-                  "from": "code-point-at@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
@@ -5239,12 +5251,12 @@
             },
             "window-size": {
               "version": "0.1.4",
-              "from": "window-size@>=0.1.4 <0.2.0",
+              "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
             },
             "y18n": {
               "version": "3.2.0",
-              "from": "y18n@>=3.2.0 <4.0.0",
+              "from": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz",
               "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
             }
           }
@@ -5253,17 +5265,17 @@
     },
     "sequelize-json": {
       "version": "2.1.2",
-      "from": "sequelize-json@>=2.1.0 <3.0.0",
+      "from": "https://registry.npmjs.org/sequelize-json/-/sequelize-json-2.1.2.tgz",
       "resolved": "https://registry.npmjs.org/sequelize-json/-/sequelize-json-2.1.2.tgz"
     },
     "sqlite3": {
       "version": "3.1.1",
-      "from": "sqlite3@>=3.1.0 <4.0.0",
+      "from": "https://registry.npmjs.org/sqlite3/-/sqlite3-3.1.1.tgz",
       "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-3.1.1.tgz",
       "dependencies": {
         "nan": {
           "version": "2.1.0",
-          "from": "nan@>=2.1.0 <2.2.0",
+          "from": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
         },
         "node-pre-gyp": {
@@ -5990,115 +6002,115 @@
     },
     "tedious": {
       "version": "1.13.2",
-      "from": "tedious@>=1.12.3 <2.0.0",
+      "from": "https://registry.npmjs.org/tedious/-/tedious-1.13.2.tgz",
       "resolved": "https://registry.npmjs.org/tedious/-/tedious-1.13.2.tgz",
       "dependencies": {
         "babel-runtime": {
           "version": "5.8.35",
-          "from": "babel-runtime@>=5.8.19 <6.0.0",
+          "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
           "dependencies": {
             "core-js": {
               "version": "1.2.6",
-              "from": "core-js@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
               "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
             }
           }
         },
         "big-number": {
           "version": "0.3.1",
-          "from": "big-number@0.3.1",
+          "from": "https://registry.npmjs.org/big-number/-/big-number-0.3.1.tgz",
           "resolved": "https://registry.npmjs.org/big-number/-/big-number-0.3.1.tgz"
         },
         "bl": {
           "version": "1.1.2",
-          "from": "bl@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz"
         },
         "iconv-lite": {
           "version": "0.4.13",
-          "from": "iconv-lite@>=0.4.11 <0.5.0",
+          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
         },
         "readable-stream": {
           "version": "2.0.5",
-          "from": "readable-stream@>=2.0.2 <3.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "process-nextick-args": {
               "version": "1.0.6",
-              "from": "process-nextick-args@>=1.0.6 <1.1.0",
+              "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
               "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "string_decoder@>=0.10.0 <0.11.0",
+              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "from": "util-deprecate@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
             }
           }
         },
         "sprintf": {
           "version": "0.1.5",
-          "from": "sprintf@0.1.5",
+          "from": "https://registry.npmjs.org/sprintf/-/sprintf-0.1.5.tgz",
           "resolved": "https://registry.npmjs.org/sprintf/-/sprintf-0.1.5.tgz"
         }
       }
     },
     "tweetnacl": {
       "version": "0.13.3",
-      "from": "tweetnacl@>=0.13.1 <0.14.0",
+      "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
     },
     "umzug": {
       "version": "1.9.0",
-      "from": "umzug@>=1.6.0 <2.0.0",
+      "from": "https://registry.npmjs.org/umzug/-/umzug-1.9.0.tgz",
       "resolved": "https://registry.npmjs.org/umzug/-/umzug-1.9.0.tgz",
       "dependencies": {
         "bluebird": {
           "version": "3.3.1",
-          "from": "bluebird@>=3.0.1 <4.0.0",
+          "from": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz"
         },
         "lodash": {
           "version": "4.5.0",
-          "from": "lodash@>=4.3.0 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.5.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.5.0.tgz"
         },
         "redefine": {
           "version": "0.2.1",
-          "from": "redefine@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/redefine/-/redefine-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/redefine/-/redefine-0.2.1.tgz"
         },
         "resolve": {
           "version": "1.1.7",
-          "from": "resolve@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
         }
       }
     },
     "uuid4": {
       "version": "1.0.0",
-      "from": "uuid4@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/uuid4/-/uuid4-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/uuid4/-/uuid4-1.0.0.tgz"
     }
   }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "moment": "^2.10.2",
     "nodemon": "^1.3.5",
     "passport-anonymous": "^1.0.1",
+    "passport-client-certificate": "^0.1.1",
     "passport-http": "^0.3.0",
     "passport-http-signature": "^1.0.0",
     "priorityqueuejs": "^1.0.0",

--- a/src/models/db/account.js
+++ b/src/models/db/account.js
@@ -54,6 +54,7 @@ class Account extends Model {
     delete data.primary
     delete data.password_hash
     delete data.public_key
+    delete data.fingerprint
     if (!data.connector) delete data.connector
     if (!data.is_admin) delete data.is_admin
     return data
@@ -88,6 +89,13 @@ class Account extends Model {
   static findByName (name, options) {
     return Account.findOne({
       where: {name: name},
+      transaction: options && options.transaction
+    })
+  }
+
+  static findByFingerprint (fingerprint, options) {
+    return Account.findOne({
+      where: {fingerprint: fingerprint},
       transaction: options && options.transaction
     })
   }
@@ -131,7 +139,13 @@ PersistentModelMixin(Account, sequelize, {
   password_hash: Sequelize.STRING,
   public_key: Sequelize.TEXT,
   is_admin: Sequelize.BOOLEAN,
-  is_disabled: Sequelize.BOOLEAN
-})
+  is_disabled: Sequelize.BOOLEAN,
+  fingerprint: Sequelize.STRING
+},
+  {
+    indexes: [
+      {fields: ['fingerprint']}
+    ]
+  })
 
 exports.Account = Account

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -20,11 +20,6 @@ if (admin_pass) {
   }
 }
 
-localConfig.auth = {
-  basic_enabled: Config.castBool(Config.getEnv('AUTH_BASIC_ENABLED'), true),
-  http_signature_enabled: Config.castBool(Config.getEnv('AUTH_HTTP_SIGNATURE_ENABLED'), true)
-}
-
 if (isRunningTests()) {
   localConfig.keys = {
     ed25519: {


### PR DESCRIPTION
Server-side Client Certificate Authentication

Uses https://github.com/ripple/passport-client-certificate

Working example:

Server
```diff
   _makeRouter () {
     const router = new Router()
-    router.get('/health', health.getResource)
+
+    router.get('/health',
+        passport.authenticate(['client-cert']),
+        health.getResource)

```

Client
```js
var fs = require('fs');
var https = require('https');

var options = {
  hostname: 'localhost',
  port: 3000,
  path: '/health',
  method: 'GET',
  key: fs.readFileSync('client1-key.pem'),
  cert: fs.readFileSync('client1-crt.pem'),
  ca: fs.readFileSync('ca-crt.pem') // Trust the test servers self-signed cert
};

var req = https.request(options, function(res) {
  res.on('data', function(data) {
    process.stdout.write(data);
  });
});
req.end();
```

```shell
$ LEDGER_TLS_KEY=server-key.pem \
  LEDGER_TLS_CERTIFICATE=server-crt.pem \
  LEDGER_TLS_CA=ca-crt.pem \
  LEDGER_PUBLIC_HTTPS=true LEDGER_DB_SYNC=1 \
  LEDGER_DB_URI=sqlite://:memory: \
  npm start
```

Certificates for this example can be found at:
https://github.com/ripple/passport-client-certificate/tree/master/test/data
