### PR TITLE
Update npm-shrinkwrap.json

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,2115 +1,1442 @@
 {
   "name": "five-bells-ledger",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "dependencies": {
     "abbrev": {
       "version": "1.0.7",
-      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+      "from": "abbrev@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
     },
     "accepts": {
-      "version": "1.3.0",
-      "from": "https://registry.npmjs.org/accepts/-/accepts-1.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.0.tgz"
+      "version": "1.3.1",
+      "from": "accepts@>=1.2.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.1.tgz"
     },
     "align-text": {
-      "version": "0.1.3",
-      "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz"
+      "version": "0.1.4",
+      "from": "align-text@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
     },
     "amdefine": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+      "from": "amdefine@>=0.0.4",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
     },
     "ansi-escapes": {
-      "version": "1.1.0",
-      "from": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.1.0.tgz"
-    },
-    "ansi-green": {
-      "version": "0.1.1",
-      "from": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
-      "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz"
+      "version": "1.1.1",
+      "from": "ansi-escapes@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.1.1.tgz"
     },
     "ansi-regex": {
       "version": "2.0.0",
-      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+      "from": "ansi-regex@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
     },
     "ansi-styles": {
       "version": "2.1.0",
-      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+      "from": "ansi-styles@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
     },
-    "ansi-wrap": {
-      "version": "0.1.0",
-      "from": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+    "any-promise": {
+      "version": "1.1.0",
+      "from": "any-promise@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.1.0.tgz"
     },
     "anymatch": {
       "version": "1.3.0",
-      "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+      "from": "anymatch@>=1.3.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz"
     },
     "ap": {
       "version": "0.2.0",
-      "from": "https://registry.npmjs.org/ap/-/ap-0.2.0.tgz",
+      "from": "ap@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/ap/-/ap-0.2.0.tgz"
+    },
+    "apidoc-core": {
+      "version": "0.4.2",
+      "from": "apidoc-core@>=0.4.2 <0.5.0",
+      "resolved": "https://registry.npmjs.org/apidoc-core/-/apidoc-core-0.4.2.tgz"
     },
     "archy": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "from": "archy@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
     },
     "argparse": {
-      "version": "1.0.3",
-      "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz"
+      "version": "1.0.6",
+      "from": "argparse@>=1.0.3 <1.1.0",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.6.tgz"
     },
     "arr-diff": {
-      "version": "1.1.0",
-      "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz"
+      "version": "2.0.0",
+      "from": "arr-diff@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
     },
     "arr-flatten": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
+      "from": "arr-flatten@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
     },
     "array-differ": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+      "from": "array-differ@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
     },
-    "array-slice": {
-      "version": "0.2.3",
-      "from": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
-      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
+    "array-find-index": {
+      "version": "1.0.1",
+      "from": "array-find-index@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
     },
     "array-union": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+      "from": "array-union@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz"
     },
     "array-uniq": {
       "version": "1.0.2",
-      "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
+      "from": "array-uniq@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
     },
     "array-unique": {
       "version": "0.2.1",
-      "from": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "from": "array-unique@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
     },
     "arrify": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
+      "version": "1.0.1",
+      "from": "arrify@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
     },
     "asn1": {
       "version": "0.2.3",
-      "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "from": "asn1@>=0.2.3 <0.3.0",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
     },
     "assert-plus": {
-      "version": "0.1.5",
-      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+      "version": "0.2.0",
+      "from": "assert-plus@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
     },
     "assertion-error": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.1.tgz",
+      "from": "assertion-error@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.1.tgz"
     },
     "async": {
-      "version": "1.5.0",
-      "from": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+      "version": "1.5.2",
+      "from": "async@>=1.4.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
     },
     "async-each": {
       "version": "0.1.6",
-      "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
+      "from": "async-each@>=0.1.6 <0.2.0",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
     },
     "aws-sign2": {
       "version": "0.6.0",
-      "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "from": "aws-sign2@>=0.6.0 <0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
     },
+    "aws4": {
+      "version": "1.2.1",
+      "from": "aws4@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.2.1.tgz"
+    },
     "babel-runtime": {
-      "version": "5.8.34",
-      "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz"
+      "version": "5.8.35",
+      "from": "babel-runtime@>=5.8.19 <6.0.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz"
     },
     "balanced-match": {
-      "version": "0.2.1",
-      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+      "version": "0.3.0",
+      "from": "balanced-match@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
     },
     "bcrypt": {
       "version": "0.8.5",
-      "from": "https://registry.npmjs.org/bcrypt/-/bcrypt-0.8.5.tgz",
-      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-0.8.5.tgz",
-      "dependencies": {
-        "bindings": {
-          "version": "1.2.1",
-          "from": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
-        },
-        "nan": {
-          "version": "2.0.5",
-          "from": "https://registry.npmjs.org/nan/-/nan-2.0.5.tgz",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.5.tgz"
-        }
-      }
+      "from": "bcrypt@>=0.8.5 <0.9.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-0.8.5.tgz"
     },
     "beeper": {
       "version": "1.1.0",
-      "from": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
+      "from": "beeper@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
     },
     "big-number": {
       "version": "0.3.1",
-      "from": "https://registry.npmjs.org/big-number/-/big-number-0.3.1.tgz",
+      "from": "big-number@0.3.1",
       "resolved": "https://registry.npmjs.org/big-number/-/big-number-0.3.1.tgz"
     },
     "bignumber.js": {
-      "version": "2.0.7",
-      "from": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-2.0.7.tgz",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-2.0.7.tgz"
+      "version": "2.1.4",
+      "from": "bignumber.js@2.1.4",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-2.1.4.tgz"
     },
     "binary-extensions": {
       "version": "1.4.0",
-      "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz",
+      "from": "binary-extensions@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
     },
+    "bindings": {
+      "version": "1.2.1",
+      "from": "bindings@1.2.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
+    },
     "bl": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+      "version": "1.0.3",
+      "from": "bl@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz"
     },
     "bluebird": {
-      "version": "3.0.5",
-      "from": "https://registry.npmjs.org/bluebird/-/bluebird-3.0.5.tgz",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.0.5.tgz"
+      "version": "3.3.1",
+      "from": "bluebird@>=3.1.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz"
     },
     "boom": {
       "version": "2.10.1",
-      "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "from": "boom@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
     },
     "brace-expansion": {
-      "version": "1.1.1",
-      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz"
+      "version": "1.1.3",
+      "from": "brace-expansion@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz"
     },
     "braces": {
-      "version": "1.8.2",
-      "from": "https://registry.npmjs.org/braces/-/braces-1.8.2.tgz",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.2.tgz"
+      "version": "1.8.3",
+      "from": "braces@>=1.8.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz"
     },
     "buffer-writer": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.0.tgz"
+      "version": "1.0.1",
+      "from": "buffer-writer@1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz"
     },
     "builtin-modules": {
-      "version": "1.1.0",
-      "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
+      "version": "1.1.1",
+      "from": "builtin-modules@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
     },
     "bytes": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+      "from": "bytes@1.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
     },
     "camelcase": {
-      "version": "2.0.1",
-      "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz"
+      "version": "2.1.0",
+      "from": "camelcase@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
     },
     "camelcase-keys": {
       "version": "2.0.0",
-      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
+      "from": "camelcase-keys@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz"
     },
     "canonical-json": {
       "version": "0.0.4",
-      "from": "https://registry.npmjs.org/canonical-json/-/canonical-json-0.0.4.tgz",
+      "from": "canonical-json@0.0.4",
       "resolved": "https://registry.npmjs.org/canonical-json/-/canonical-json-0.0.4.tgz"
     },
     "caseless": {
       "version": "0.11.0",
-      "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "from": "caseless@>=0.11.0 <0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
     },
     "center-align": {
-      "version": "0.1.2",
-      "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz"
+      "version": "0.1.3",
+      "from": "center-align@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
+    },
+    "chai": {
+      "version": "3.5.0",
+      "from": "chai@>=3.2.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz"
     },
     "chalk": {
       "version": "1.1.1",
-      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+      "from": "chalk@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
     },
     "chokidar": {
-      "version": "1.3.0",
-      "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.3.0.tgz",
-      "dependencies": {
-        "fsevents": {
-          "version": "1.0.6",
-          "from": "fsevents@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.6.tgz",
-          "dependencies": {
-            "node-pre-gyp": {
-              "version": "0.6.17",
-              "from": "node-pre-gyp@>=0.6.17 <0.7.0",
-              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.17.tgz",
-              "dependencies": {
-                "nopt": {
-                  "version": "3.0.6",
-                  "from": "nopt@~3.0.1",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-                  "dependencies": {
-                    "abbrev": {
-                      "version": "1.0.7",
-                      "from": "abbrev@1",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "ansi": {
-              "version": "0.3.0",
-              "from": "ansi@~0.3.0",
-              "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
-            },
-            "ansi-regex": {
-              "version": "2.0.0",
-              "from": "ansi-regex@^2.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-            },
-            "ansi-styles": {
-              "version": "2.1.0",
-              "from": "ansi-styles@^2.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-            },
-            "are-we-there-yet": {
-              "version": "1.0.4",
-              "from": "are-we-there-yet@~1.0.0",
-              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz"
-            },
-            "asn1": {
-              "version": "0.2.3",
-              "from": "asn1@>=0.2.3 <0.3.0",
-              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-            },
-            "assert-plus": {
-              "version": "0.1.5",
-              "from": "assert-plus@^0.1.5",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-            },
-            "async": {
-              "version": "1.5.0",
-              "from": "async@^1.4.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
-            },
-            "aws-sign2": {
-              "version": "0.6.0",
-              "from": "aws-sign2@~0.6.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-            },
-            "block-stream": {
-              "version": "0.0.8",
-              "from": "block-stream@*",
-              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
-            },
-            "boom": {
-              "version": "2.10.1",
-              "from": "boom@2.x.x",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-            },
-            "caseless": {
-              "version": "0.11.0",
-              "from": "caseless@~0.11.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "from": "combined-stream@~1.0.5",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
-            },
-            "commander": {
-              "version": "2.9.0",
-              "from": "commander@^2.9.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "from": "core-util-is@~1.0.0",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-            },
-            "chalk": {
-              "version": "1.1.1",
-              "from": "chalk@^1.1.1",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
-            },
-            "dashdash": {
-              "version": "1.10.1",
-              "from": "dashdash@>=1.10.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz"
-            },
-            "cryptiles": {
-              "version": "2.0.5",
-              "from": "cryptiles@2.x.x",
-              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-            },
-            "debug": {
-              "version": "0.7.4",
-              "from": "debug@~0.7.2",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-            },
-            "delayed-stream": {
-              "version": "1.0.0",
-              "from": "delayed-stream@~1.0.0",
-              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-            },
-            "delegates": {
-              "version": "0.1.0",
-              "from": "delegates@^0.1.0",
-              "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
-            },
-            "deep-extend": {
-              "version": "0.4.0",
-              "from": "deep-extend@~0.4.0",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "escape-string-regexp@^1.0.2",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-            },
-            "ecc-jsbn": {
-              "version": "0.1.1",
-              "from": "ecc-jsbn@>=0.0.1 <1.0.0",
-              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
-            },
-            "extsprintf": {
-              "version": "1.0.2",
-              "from": "extsprintf@1.0.2",
-              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-            },
-            "extend": {
-              "version": "3.0.0",
-              "from": "extend@~3.0.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "from": "forever-agent@~0.6.1",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-            },
-            "form-data": {
-              "version": "1.0.0-rc3",
-              "from": "form-data@~1.0.0-rc3",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
-            },
-            "fstream": {
-              "version": "1.0.8",
-              "from": "fstream@^1.0.2",
-              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
-            },
-            "gauge": {
-              "version": "1.2.2",
-              "from": "gauge@~1.2.0",
-              "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz"
-            },
-            "generate-function": {
-              "version": "2.0.0",
-              "from": "generate-function@^2.0.0",
-              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-            },
-            "generate-object-property": {
-              "version": "1.2.0",
-              "from": "generate-object-property@^1.1.0",
-              "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
-            },
-            "graceful-fs": {
-              "version": "4.1.2",
-              "from": "graceful-fs@4.1",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-            },
-            "graceful-readlink": {
-              "version": "1.0.1",
-              "from": "graceful-readlink@>= 1.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "has-ansi@^2.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
-            },
-            "har-validator": {
-              "version": "2.0.3",
-              "from": "har-validator@~2.0.2",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz"
-            },
-            "has-unicode": {
-              "version": "1.0.1",
-              "from": "has-unicode@^1.0.0",
-              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
-            },
-            "hoek": {
-              "version": "2.16.3",
-              "from": "hoek@2.x.x",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-            },
-            "hawk": {
-              "version": "3.1.2",
-              "from": "hawk@~3.1.0",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz"
-            },
-            "http-signature": {
-              "version": "1.1.0",
-              "from": "http-signature@~1.1.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz"
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@*",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "ini": {
-              "version": "1.3.4",
-              "from": "ini@~1.3.0",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-            },
-            "is-property": {
-              "version": "1.0.2",
-              "from": "is-property@^1.0.0",
-              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-            },
-            "is-my-json-valid": {
-              "version": "2.12.3",
-              "from": "is-my-json-valid@^2.12.3",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz"
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "from": "isstream@~0.1.2",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "from": "is-typedarray@~1.0.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-            },
-            "isarray": {
-              "version": "0.0.1",
-              "from": "isarray@0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-            },
-            "jodid25519": {
-              "version": "1.0.2",
-              "from": "jodid25519@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
-            },
-            "jsbn": {
-              "version": "0.1.0",
-              "from": "jsbn@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-            },
-            "json-schema": {
-              "version": "0.2.2",
-              "from": "json-schema@0.2.2",
-              "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
-            },
-            "jsonpointer": {
-              "version": "2.0.0",
-              "from": "jsonpointer@2.0.0",
-              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "from": "json-stringify-safe@~5.0.1",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-            },
-            "jsprim": {
-              "version": "1.2.2",
-              "from": "jsprim@^1.2.2",
-              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
-            },
-            "lodash._basetostring": {
-              "version": "3.0.1",
-              "from": "lodash._basetostring@^3.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
-            },
-            "lodash.pad": {
-              "version": "3.1.1",
-              "from": "lodash.pad@^3.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
-            },
-            "lodash._createpadding": {
-              "version": "3.6.1",
-              "from": "lodash._createpadding@^3.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
-            },
-            "lodash.padleft": {
-              "version": "3.1.1",
-              "from": "lodash.padleft@^3.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
-            },
-            "lodash.repeat": {
-              "version": "3.0.1",
-              "from": "lodash.repeat@^3.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
-            },
-            "lodash.padright": {
-              "version": "3.1.1",
-              "from": "lodash.padright@^3.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
-            },
-            "mime-db": {
-              "version": "1.19.0",
-              "from": "mime-db@~1.19.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
-            },
-            "minimist": {
-              "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-            },
-            "mime-types": {
-              "version": "2.1.7",
-              "from": "mime-types@~2.1.7",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz"
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-            },
-            "node-uuid": {
-              "version": "1.4.7",
-              "from": "node-uuid@~1.4.7",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
-            },
-            "npmlog": {
-              "version": "2.0.0",
-              "from": "npmlog@~2.0.0",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.0.tgz"
-            },
-            "oauth-sign": {
-              "version": "0.8.0",
-              "from": "oauth-sign@~0.8.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
-            },
-            "once": {
-              "version": "1.1.1",
-              "from": "once@~1.1.1",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
-            },
-            "pinkie": {
-              "version": "2.0.1",
-              "from": "pinkie@^2.0.0",
-              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
-            },
-            "pinkie-promise": {
-              "version": "2.0.0",
-              "from": "pinkie-promise@^2.0.0",
-              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
-            },
-            "qs": {
-              "version": "5.2.0",
-              "from": "qs@~5.2.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
-            },
-            "readable-stream": {
-              "version": "1.1.13",
-              "from": "readable-stream@^1.1.13",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
-            },
-            "request": {
-              "version": "2.67.0",
-              "from": "request@2.x",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz"
-            },
-            "semver": {
-              "version": "5.1.0",
-              "from": "semver@~5.1.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
-            },
-            "sntp": {
-              "version": "1.0.9",
-              "from": "sntp@1.x.x",
-              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "from": "string_decoder@~0.10.x",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-            },
-            "strip-ansi": {
-              "version": "3.0.0",
-              "from": "strip-ansi@^3.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
-            },
-            "strip-json-comments": {
-              "version": "1.0.4",
-              "from": "strip-json-comments@~1.0.4",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "from": "stringstream@~0.0.4",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@^2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            },
-            "tar": {
-              "version": "2.2.1",
-              "from": "tar@~2.2.0",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
-            },
-            "tough-cookie": {
-              "version": "2.2.1",
-              "from": "tough-cookie@~2.2.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
-            },
-            "tunnel-agent": {
-              "version": "0.4.1",
-              "from": "tunnel-agent@~0.4.1",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
-            },
-            "tweetnacl": {
-              "version": "0.13.2",
-              "from": "tweetnacl@>=0.13.0 <1.0.0",
-              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
-            },
-            "uid-number": {
-              "version": "0.0.3",
-              "from": "uid-number@0.0.3",
-              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
-            },
-            "verror": {
-              "version": "1.3.6",
-              "from": "verror@1.3.6",
-              "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "from": "xtend@^4.0.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            },
-            "rc": {
-              "version": "1.1.5",
-              "from": "rc@~1.1.0",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.5.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "from": "minimist@^1.2.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                }
-              }
-            },
-            "sshpk": {
-              "version": "1.7.0",
-              "from": "sshpk@^1.7.0",
-              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.0.tgz",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.2.0",
-                  "from": "assert-plus@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-                }
-              }
-            },
-            "bl": {
-              "version": "1.0.0",
-              "from": "bl@~1.0.0",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.0.4",
-                  "from": "readable-stream@~2.0.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.3",
-                      "from": "process-nextick-args@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "util-deprecate@~1.0.1",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "tar-pack": {
-              "version": "3.1.0",
-              "from": "tar-pack@~3.1.0",
-              "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.0.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "readable-stream@~1.0.2",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@~2.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    }
-                  }
-                },
-                "rimraf": {
-                  "version": "2.2.8",
-                  "from": "rimraf@~2.2.0",
-                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-                }
-              }
-            },
-            "fstream-ignore": {
-              "version": "1.0.3",
-              "from": "fstream-ignore@~1.0.3",
-              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz",
-              "dependencies": {
-                "minimatch": {
-                  "version": "3.0.0",
-                  "from": "minimatch@^3.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.1",
-                      "from": "brace-expansion@^1.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.2.1",
-                          "from": "balanced-match@^0.2.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "rimraf": {
-              "version": "2.4.4",
-              "from": "rimraf@~2.4.0",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.4.tgz",
-              "dependencies": {
-                "glob": {
-                  "version": "5.0.15",
-                  "from": "glob@^5.0.14",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "from": "inflight@^1.0.4",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@1",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@2",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "minimatch": {
-                      "version": "3.0.0",
-                      "from": "minimatch@2 || 3",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.1",
-                          "from": "brace-expansion@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.2.1",
-                              "from": "balanced-match@^0.2.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.3.3",
-                      "from": "once@^1.3.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@1",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.0",
-                      "from": "path-is-absolute@^1.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+      "version": "1.4.2",
+      "from": "chokidar@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.2.tgz"
     },
     "cli-color": {
       "version": "0.3.3",
-      "from": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz",
+      "from": "cli-color@>=0.3.2 <0.4.0",
       "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz"
     },
     "cli-cursor": {
       "version": "1.0.2",
-      "from": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "from": "cli-cursor@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz"
     },
     "cli-width": {
-      "version": "1.1.0",
-      "from": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.0.tgz"
+      "version": "1.1.1",
+      "from": "cli-width@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz"
     },
     "cliui": {
-      "version": "2.1.0",
-      "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.2",
-          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-        }
-      }
+      "version": "3.1.0",
+      "from": "cliui@>=3.0.3 <4.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.1.0.tgz"
     },
     "clone": {
       "version": "1.0.2",
-      "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+      "from": "clone@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
     },
     "clone-stats": {
       "version": "0.0.1",
-      "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+      "from": "clone-stats@>=0.0.1 <0.0.2",
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
     },
     "co": {
       "version": "4.6.0",
-      "from": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "from": "co@>=4.1.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
     },
     "co-body": {
       "version": "1.2.0",
-      "from": "https://registry.npmjs.org/co-body/-/co-body-1.2.0.tgz",
+      "from": "co-body@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/co-body/-/co-body-1.2.0.tgz",
       "dependencies": {
         "qs": {
           "version": "2.3.3",
-          "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+          "from": "qs@>=2.3.3 <2.4.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
         }
       }
     },
     "co-defer": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/co-defer/-/co-defer-1.0.0.tgz",
+      "from": "co-defer@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/co-defer/-/co-defer-1.0.0.tgz"
     },
     "co-emitter": {
       "version": "0.2.3",
-      "from": "https://registry.npmjs.org/co-emitter/-/co-emitter-0.2.3.tgz",
+      "from": "co-emitter@>=0.2.3 <0.3.0",
       "resolved": "https://registry.npmjs.org/co-emitter/-/co-emitter-0.2.3.tgz"
     },
     "co-request": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/co-request/-/co-request-1.0.0.tgz",
+      "from": "co-request@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/co-request/-/co-request-1.0.0.tgz"
     },
     "code-point-at": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+      "from": "code-point-at@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz"
     },
     "colors": {
       "version": "1.0.3",
-      "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "from": "colors@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
     },
     "combined-stream": {
       "version": "1.0.5",
-      "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "from": "combined-stream@>=1.0.5 <1.1.0",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
     },
     "commander": {
       "version": "2.9.0",
-      "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "from": "commander@>=2.9.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
     },
     "component-emitter": {
-      "version": "1.1.2",
-      "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+      "version": "1.2.0",
+      "from": "component-emitter@>=1.2.0 <1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz"
     },
     "composition": {
       "version": "2.2.1",
-      "from": "https://registry.npmjs.org/composition/-/composition-2.2.1.tgz",
+      "from": "composition@>=2.1.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/composition/-/composition-2.2.1.tgz"
     },
     "compressible": {
-      "version": "2.0.6",
-      "from": "https://registry.npmjs.org/compressible/-/compressible-2.0.6.tgz",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.6.tgz"
+      "version": "2.0.7",
+      "from": "compressible@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.7.tgz"
     },
     "concat-map": {
       "version": "0.0.1",
-      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "from": "concat-map@0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
     },
     "concat-stream": {
       "version": "1.5.1",
-      "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+      "from": "concat-stream@>=1.5.0 <1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz"
     },
     "config-chain": {
-      "version": "1.1.9",
-      "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
-      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz"
+      "version": "1.1.10",
+      "from": "config-chain@>=1.1.5 <1.2.0",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz"
     },
     "configstore": {
-      "version": "1.3.0",
-      "from": "https://registry.npmjs.org/configstore/-/configstore-1.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.3.0.tgz"
+      "version": "1.4.0",
+      "from": "configstore@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz"
     },
     "content-disposition": {
-      "version": "0.5.0",
-      "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz"
+      "version": "0.5.1",
+      "from": "content-disposition@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
     },
     "content-type": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz",
+      "from": "content-type@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
     },
     "cookiejar": {
-      "version": "2.0.1",
-      "from": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.1.tgz"
+      "version": "2.0.6",
+      "from": "cookiejar@2.0.6",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz"
     },
     "cookies": {
       "version": "0.5.1",
-      "from": "https://registry.npmjs.org/cookies/-/cookies-0.5.1.tgz",
+      "from": "cookies@>=0.5.0 <0.6.0",
       "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.5.1.tgz"
     },
     "core-js": {
       "version": "1.2.6",
-      "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+      "from": "core-js@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
     },
     "core-util-is": {
       "version": "1.0.2",
-      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "from": "core-util-is@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
     "cryptiles": {
       "version": "2.0.5",
-      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "from": "cryptiles@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
     },
     "cycle": {
       "version": "1.0.3",
-      "from": "cycle@1.0.3",
+      "from": "cycle@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
     },
     "d": {
       "version": "0.1.1",
-      "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+      "from": "d@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
     },
     "dashdash": {
-      "version": "1.10.1",
-      "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz"
+      "version": "1.13.0",
+      "from": "dashdash@>=1.10.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        }
+      }
     },
     "dateformat": {
       "version": "1.0.12",
-      "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+      "from": "dateformat@>=1.0.11 <2.0.0",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz"
     },
     "debug": {
       "version": "2.2.0",
-      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "from": "debug@>=2.2.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
     },
     "decamelize": {
-      "version": "1.1.1",
-      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
+      "version": "1.1.2",
+      "from": "decamelize@>=1.1.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz"
     },
     "deep-diff": {
       "version": "0.3.3",
-      "from": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.3.tgz",
+      "from": "deep-diff@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.3.tgz"
     },
     "deep-eql": {
       "version": "0.1.3",
-      "from": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "from": "deep-eql@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "dependencies": {
         "type-detect": {
           "version": "0.1.1",
-          "from": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "from": "type-detect@0.1.1",
           "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
         }
       }
     },
     "deep-equal": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "from": "deep-equal@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
     },
     "deep-extend": {
-      "version": "0.4.0",
-      "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz"
+      "version": "0.4.1",
+      "from": "deep-extend@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
     },
     "deep-is": {
       "version": "0.1.3",
-      "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "from": "deep-is@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
     },
     "defaults": {
       "version": "1.0.3",
-      "from": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "from": "defaults@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz"
     },
     "del": {
-      "version": "2.1.0",
-      "from": "https://registry.npmjs.org/del/-/del-2.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.1.0.tgz",
-      "dependencies": {
-        "pinkie-promise": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
-        },
-        "pinkie": {
-          "version": "2.0.1",
-          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
-        }
-      }
+      "version": "2.2.0",
+      "from": "del@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.0.tgz"
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "from": "delayed-stream@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
     },
     "delegates": {
       "version": "0.1.0",
-      "from": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz",
+      "from": "delegates@0.1.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
     },
     "depd": {
       "version": "1.1.0",
-      "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+      "from": "depd@1.1.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
     },
     "deprecated": {
       "version": "0.0.1",
-      "from": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
+      "from": "deprecated@>=0.0.1 <0.0.2",
       "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz"
     },
     "destroy": {
-      "version": "1.0.3",
-      "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
+      "version": "1.0.4",
+      "from": "destroy@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
     },
     "diff": {
       "version": "1.4.0",
-      "from": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "from": "diff@1.4.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
     },
     "doctrine": {
-      "version": "0.7.1",
-      "from": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.1.tgz",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.1.tgz",
+      "version": "0.7.2",
+      "from": "doctrine@>=0.7.1 <0.8.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
       "dependencies": {
         "esutils": {
           "version": "1.1.6",
-          "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+          "from": "esutils@>=1.1.6 <2.0.0",
           "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
         }
       }
     },
     "dottie": {
-      "version": "1.1.0",
-      "from": "https://registry.npmjs.org/dottie/-/dottie-1.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/dottie/-/dottie-1.1.0.tgz"
+      "version": "1.1.1",
+      "from": "dottie@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/dottie/-/dottie-1.1.1.tgz"
     },
     "duplexer": {
       "version": "0.1.1",
-      "from": "duplexer@0.1.1",
+      "from": "duplexer@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
     },
     "duplexer2": {
       "version": "0.0.2",
-      "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+      "from": "duplexer2@0.0.2",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "dependencies": {
         "readable-stream": {
           "version": "1.1.13",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+          "from": "readable-stream@>=1.1.9 <1.2.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
         }
       }
     },
     "duplexify": {
       "version": "3.4.2",
-      "from": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
+      "from": "duplexify@>=3.2.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz"
     },
     "ecc-jsbn": {
-      "version": "0.0.1",
-      "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.0.1.tgz",
-      "dependencies": {
-        "jsbn": {
-          "version": "0.0.0",
-          "from": "git+https://github.com/rynomad/jsbn.git#bb522b0124f75424f89d49446c40a87111942c7b",
-          "resolved": "git+https://github.com/rynomad/jsbn.git#bb522b0124f75424f89d49446c40a87111942c7b"
-        }
-      }
+      "version": "0.1.1",
+      "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
     },
     "ee-first": {
       "version": "1.1.1",
-      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "from": "ee-first@1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
     },
     "end-of-stream": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+      "from": "end-of-stream@1.0.0",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz"
     },
     "entities": {
       "version": "1.1.1",
-      "from": "entities@1.1.1",
+      "from": "entities@>=1.1.1 <1.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
     },
     "error-ex": {
       "version": "1.3.0",
-      "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+      "from": "error-ex@>=1.2.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
     },
     "error-inject": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/error-inject/-/error-inject-1.0.0.tgz",
+      "from": "error-inject@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/error-inject/-/error-inject-1.0.0.tgz"
     },
     "es5-ext": {
-      "version": "0.10.8",
-      "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz"
+      "version": "0.10.11",
+      "from": "es5-ext@>=0.10.6 <0.11.0",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
     },
     "es6-iterator": {
       "version": "2.0.0",
-      "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
+      "from": "es6-iterator@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
     },
     "es6-map": {
       "version": "0.1.3",
-      "from": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.3.tgz",
+      "from": "es6-map@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.3.tgz"
     },
     "es6-promise": {
-      "version": "3.0.2",
-      "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz"
+      "version": "3.1.2",
+      "from": "es6-promise@>=3.0.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.1.2.tgz"
     },
     "es6-set": {
-      "version": "0.1.3",
-      "from": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.3.tgz",
-      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.3.tgz"
+      "version": "0.1.4",
+      "from": "es6-set@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz"
     },
     "es6-symbol": {
-      "version": "3.0.1",
-      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.1.tgz"
+      "version": "3.0.2",
+      "from": "es6-symbol@>=3.0.2 <3.1.0",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
     },
     "es6-weak-map": {
       "version": "0.1.4",
-      "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+      "from": "es6-weak-map@>=0.1.4 <0.2.0",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
       "dependencies": {
         "es6-iterator": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+          "from": "es6-iterator@>=0.1.3 <0.2.0",
           "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
         },
         "es6-symbol": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+          "from": "es6-symbol@>=2.0.1 <2.1.0",
           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
         }
       }
     },
     "escape-html": {
       "version": "1.0.3",
-      "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "from": "escape-html@>=1.0.1 <1.1.0",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
     },
     "escape-string-regexp": {
-      "version": "1.0.3",
-      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+      "version": "1.0.4",
+      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
     },
     "escodegen": {
-      "version": "1.7.0",
-      "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.0.tgz",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.0.tgz",
+      "version": "1.7.1",
+      "from": "escodegen@>=1.7.0 <1.8.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.1.tgz",
       "dependencies": {
-        "estraverse": {
-          "version": "1.9.3",
-          "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
-        },
         "esprima": {
           "version": "1.2.5",
-          "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+          "from": "esprima@>=1.2.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+        },
+        "estraverse": {
+          "version": "1.9.3",
+          "from": "estraverse@>=1.9.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
         },
         "optionator": {
           "version": "0.5.0",
-          "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+          "from": "optionator@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz"
         },
         "source-map": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "from": "source-map@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz"
+        }
+      }
+    },
+    "escope": {
+      "version": "3.4.0",
+      "from": "escope@>=3.3.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.4.0.tgz",
+      "dependencies": {
+        "es6-weak-map": {
+          "version": "2.0.1",
+          "from": "es6-weak-map@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz"
         }
       }
     },
     "esprima": {
       "version": "1.0.4",
-      "from": "esprima@1.0.4",
+      "from": "esprima@>=1.0.2 <1.1.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
     },
     "esrecurse": {
       "version": "3.1.1",
-      "from": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz",
+      "from": "esrecurse@>=3.1.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz",
       "dependencies": {
         "estraverse": {
           "version": "3.1.0",
-          "from": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz",
+          "from": "estraverse@>=3.1.0 <3.2.0",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
         }
       }
     },
     "estraverse": {
       "version": "4.1.1",
-      "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
+      "from": "estraverse@>=4.1.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
     },
     "estraverse-fb": {
       "version": "1.3.1",
-      "from": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz",
+      "from": "estraverse-fb@>=1.3.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
     },
     "esutils": {
       "version": "2.0.2",
-      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "from": "esutils@>=2.0.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
     },
     "event-emitter": {
       "version": "0.3.4",
-      "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
+      "from": "event-emitter@>=0.3.3 <0.4.0",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
     },
     "event-stream": {
       "version": "3.3.2",
-      "from": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.2.tgz",
+      "from": "event-stream@>=3.3.0 <3.4.0",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.2.tgz"
     },
     "exit-hook": {
       "version": "1.1.1",
-      "from": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "from": "exit-hook@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
     },
     "expand-brackets": {
       "version": "0.1.4",
-      "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz",
+      "from": "expand-brackets@>=0.1.4 <0.2.0",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
     },
     "expand-range": {
       "version": "1.8.1",
-      "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
+      "from": "expand-range@>=1.8.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz"
     },
     "extend": {
       "version": "3.0.0",
-      "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+      "from": "extend@>=3.0.0 <3.1.0",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
     },
     "extglob": {
-      "version": "0.3.1",
-      "from": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz"
+      "version": "0.3.2",
+      "from": "extglob@>=0.3.1 <0.4.0",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
     },
     "extsprintf": {
       "version": "1.0.2",
-      "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+      "from": "extsprintf@1.0.2",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
     },
     "eyes": {
       "version": "0.1.8",
-      "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "from": "eyes@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
     },
     "fancy-log": {
-      "version": "1.1.0",
-      "from": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.1.0.tgz"
+      "version": "1.2.0",
+      "from": "fancy-log@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.2.0.tgz"
     },
     "fast-levenshtein": {
       "version": "1.0.7",
-      "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+      "from": "fast-levenshtein@>=1.0.6 <1.1.0",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
     },
     "figures": {
       "version": "1.4.0",
-      "from": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz",
+      "from": "figures@>=1.3.5 <2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
     },
     "file-entry-cache": {
       "version": "1.2.4",
-      "from": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
+      "from": "file-entry-cache@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz"
     },
     "filename-regex": {
       "version": "2.0.0",
-      "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
+      "from": "filename-regex@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
     },
     "fileset": {
       "version": "0.2.1",
-      "from": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
+      "from": "fileset@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
       "dependencies": {
         "minimatch": {
           "version": "2.0.10",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "from": "minimatch@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
-        },
-        "glob": {
-          "version": "5.0.15",
-          "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
         }
       }
     },
     "fill-range": {
-      "version": "2.2.2",
-      "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz"
+      "version": "2.2.3",
+      "from": "fill-range@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
     },
     "find-index": {
       "version": "0.1.1",
-      "from": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
+      "from": "find-index@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
     },
     "find-up": {
       "version": "1.1.0",
-      "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
-      "dependencies": {
-        "pinkie-promise": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
-        },
-        "pinkie": {
-          "version": "2.0.1",
-          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
-        }
-      }
+      "from": "find-up@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz"
     },
     "findup-sync": {
-      "version": "0.2.1",
-      "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz"
+      "version": "0.3.0",
+      "from": "findup-sync@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz"
     },
     "first-chunk-stream": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+      "from": "first-chunk-stream@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
     },
     "five-bells-condition": {
       "version": "2.0.0",
-      "from": "https://registry.npmjs.org/five-bells-condition/-/five-bells-condition-2.0.0.tgz",
+      "from": "five-bells-condition@>=2.0.0 <2.1.0",
       "resolved": "https://registry.npmjs.org/five-bells-condition/-/five-bells-condition-2.0.0.tgz"
     },
     "five-bells-shared": {
-      "version": "9.0.1",
-      "from": "five-bells-shared@9.0.1",
-      "resolved": "https://registry.npmjs.org/five-bells-shared/-/five-bells-shared-9.0.1.tgz",
-      "dependencies": {
-        "immutable": {
-          "version": "3.7.6",
-          "from": "immutable@>=3.7.6 <4.0.0",
-          "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz"
-        }
-      }
+      "version": "9.1.2",
+      "from": "five-bells-shared@>=9.1.2 <9.2.0",
+      "resolved": "https://registry.npmjs.org/five-bells-shared/-/five-bells-shared-9.1.2.tgz"
     },
     "flagged-respawn": {
       "version": "0.3.1",
-      "from": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz",
+      "from": "flagged-respawn@>=0.3.1 <0.4.0",
       "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz"
     },
     "flat-cache": {
       "version": "1.0.10",
-      "from": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.10.tgz",
+      "from": "flat-cache@>=1.0.9 <2.0.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.10.tgz"
     },
     "for-in": {
       "version": "0.1.4",
-      "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz",
+      "from": "for-in@>=0.1.4 <0.2.0",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
     },
     "for-own": {
       "version": "0.1.3",
-      "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+      "from": "for-own@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz"
     },
     "forever-agent": {
       "version": "0.6.1",
-      "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "from": "forever-agent@>=0.6.1 <0.7.0",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
     },
     "form-data": {
       "version": "1.0.0-rc3",
-      "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+      "from": "form-data@>=1.0.0-rc3 <1.1.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
     },
     "formatio": {
       "version": "1.1.1",
-      "from": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+      "from": "formatio@1.1.1",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz"
     },
     "formidable": {
-      "version": "1.0.14",
-      "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz"
+      "version": "1.0.17",
+      "from": "formidable@>=1.0.14 <1.1.0",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
     },
     "fresh": {
       "version": "0.3.0",
-      "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+      "from": "fresh@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
     },
     "from": {
       "version": "0.1.3",
-      "from": "from@0.1.3",
+      "from": "from@>=0.0.0 <1.0.0",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
     },
     "fs-extra": {
-      "version": "0.16.5",
-      "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.5.tgz",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.5.tgz",
-      "dependencies": {
-        "graceful-fs": {
-          "version": "3.0.8",
-          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-        }
-      }
+      "version": "0.26.5",
+      "from": "fs-extra@>=0.26.3 <0.27.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.5.tgz"
     },
     "gaze": {
       "version": "0.5.2",
-      "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+      "from": "gaze@>=0.5.1 <0.6.0",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz"
     },
     "generate-function": {
       "version": "2.0.0",
-      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "from": "generate-function@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
     },
     "generate-object-property": {
       "version": "1.2.0",
-      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "from": "generate-object-property@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
     },
     "generic-pool": {
       "version": "2.1.1",
-      "from": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.1.1.tgz",
+      "from": "generic-pool@2.1.1",
       "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.1.1.tgz"
     },
     "get-stdin": {
       "version": "4.0.1",
-      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "from": "get-stdin@>=4.0.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
     },
     "glob": {
-      "version": "4.3.5",
-      "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
-      "dependencies": {
-        "minimatch": {
-          "version": "2.0.10",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
-        }
-      }
+      "version": "5.0.15",
+      "from": "glob@>=5.0.0 <5.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
     },
     "glob-base": {
       "version": "0.3.0",
-      "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "from": "glob-base@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
     },
     "glob-parent": {
       "version": "2.0.0",
-      "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "from": "glob-parent@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
     },
     "glob-stream": {
       "version": "3.1.18",
-      "from": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
+      "from": "glob-stream@>=3.1.5 <4.0.0",
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
       "dependencies": {
+        "glob": {
+          "version": "4.5.3",
+          "from": "glob@>=4.3.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz"
+        },
         "minimatch": {
           "version": "2.0.10",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "from": "minimatch@>=2.0.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
         }
       }
     },
     "glob-watcher": {
       "version": "0.0.6",
-      "from": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+      "from": "glob-watcher@>=0.0.6 <0.0.7",
       "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz"
     },
     "glob2base": {
       "version": "0.0.12",
-      "from": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+      "from": "glob2base@>=0.0.12 <0.0.13",
       "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz"
     },
     "globals": {
-      "version": "8.12.0",
-      "from": "https://registry.npmjs.org/globals/-/globals-8.12.0.tgz",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-8.12.0.tgz"
+      "version": "8.18.0",
+      "from": "globals@>=8.11.0 <9.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
     },
     "globby": {
-      "version": "3.0.1",
-      "from": "https://registry.npmjs.org/globby/-/globby-3.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-3.0.1.tgz",
+      "version": "4.0.0",
+      "from": "globby@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-4.0.0.tgz",
       "dependencies": {
         "glob": {
-          "version": "5.0.15",
-          "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
+          "version": "6.0.4",
+          "from": "glob@>=6.0.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz"
         }
       }
     },
     "globule": {
       "version": "0.1.0",
-      "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+      "from": "globule@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
       "dependencies": {
-        "lodash": {
-          "version": "1.0.2",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
-        },
         "glob": {
           "version": "3.1.21",
-          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "from": "glob@>=3.1.21 <3.2.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz"
-        },
-        "minimatch": {
-          "version": "0.2.14",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
         },
         "graceful-fs": {
           "version": "1.2.3",
-          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+          "from": "graceful-fs@>=1.2.0 <1.3.0",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
         },
         "inherits": {
           "version": "1.0.2",
-          "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+          "from": "inherits@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
+        },
+        "lodash": {
+          "version": "1.0.2",
+          "from": "lodash@>=1.0.1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "from": "minimatch@>=0.2.11 <0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
         }
       }
     },
     "glogg": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+      "from": "glogg@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz"
     },
     "got": {
       "version": "3.3.1",
-      "from": "https://registry.npmjs.org/got/-/got-3.3.1.tgz",
+      "from": "got@>=3.2.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/got/-/got-3.3.1.tgz",
       "dependencies": {
         "object-assign": {
           "version": "3.0.0",
-          "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "from": "object-assign@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
         }
       }
     },
     "graceful-fs": {
-      "version": "4.1.2",
-      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+      "version": "4.1.3",
+      "from": "graceful-fs@>=4.1.2 <5.0.0",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
     },
     "graceful-readlink": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "from": "graceful-readlink@>=1.0.0",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
     },
     "growl": {
       "version": "1.8.1",
-      "from": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
+      "from": "growl@1.8.1",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
     },
     "gulp": {
-      "version": "3.9.0",
-      "from": "https://registry.npmjs.org/gulp/-/gulp-3.9.0.tgz",
-      "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.0.tgz",
+      "version": "3.9.1",
+      "from": "gulp@>=3.8.10 <4.0.0",
+      "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "from": "minimist@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         },
         "semver": {
           "version": "4.3.6",
-          "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "from": "semver@>=4.1.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         }
       }
     },
     "gulp-help": {
       "version": "1.3.4",
-      "from": "https://registry.npmjs.org/gulp-help/-/gulp-help-1.3.4.tgz",
+      "from": "gulp-help@>=1.3.1 <1.4.0",
       "resolved": "https://registry.npmjs.org/gulp-help/-/gulp-help-1.3.4.tgz"
     },
     "gulp-util": {
       "version": "3.0.7",
-      "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
+      "from": "gulp-util@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "from": "minimist@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         },
         "object-assign": {
           "version": "3.0.0",
-          "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "from": "object-assign@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
         },
         "through2": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz"
+          "version": "2.0.1",
+          "from": "through2@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
         }
       }
     },
     "gulplog": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+      "from": "gulplog@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz"
     },
     "handlebars": {
       "version": "4.0.5",
-      "from": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
+      "from": "handlebars@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz"
     },
     "har-validator": {
-      "version": "2.0.2",
-      "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.2.tgz"
+      "version": "2.0.6",
+      "from": "har-validator@>=2.0.6 <2.1.0",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
     },
     "has-ansi": {
       "version": "2.0.0",
-      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "from": "has-ansi@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
     },
     "has-color": {
       "version": "0.1.7",
-      "from": "has-color@0.1.7",
+      "from": "has-color@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
     },
     "has-flag": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "from": "has-flag@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
     },
     "has-gulplog": {
       "version": "0.1.0",
-      "from": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+      "from": "has-gulplog@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz"
     },
     "hawk": {
-      "version": "3.1.2",
-      "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz"
+      "version": "3.1.3",
+      "from": "hawk@>=3.1.0 <3.2.0",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
     },
     "hoek": {
       "version": "2.16.3",
-      "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "from": "hoek@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
     },
     "hosted-git-info": {
       "version": "2.1.4",
-      "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
+      "from": "hosted-git-info@>=2.1.4 <3.0.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
     },
     "http-assert": {
       "version": "1.1.1",
-      "from": "https://registry.npmjs.org/http-assert/-/http-assert-1.1.1.tgz",
-      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.1.1.tgz"
+      "from": "http-assert@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.1.1.tgz",
+      "dependencies": {
+        "http-errors": {
+          "version": "1.3.1",
+          "from": "http-errors@>=1.3.1 <1.4.0",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
+        }
+      }
     },
     "http-errors": {
-      "version": "1.3.1",
-      "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
+      "version": "1.4.0",
+      "from": "http-errors@>=1.2.8 <2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz"
     },
     "http-signature": {
-      "version": "1.1.0",
-      "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz"
+      "version": "1.1.1",
+      "from": "http-signature@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
     },
     "humanize-number": {
       "version": "0.0.2",
-      "from": "https://registry.npmjs.org/humanize-number/-/humanize-number-0.0.2.tgz",
+      "from": "humanize-number@>=0.0.1 <0.1.0",
       "resolved": "https://registry.npmjs.org/humanize-number/-/humanize-number-0.0.2.tgz"
     },
     "iconv-lite": {
       "version": "0.4.8",
-      "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz",
+      "from": "iconv-lite@0.4.8",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz"
+    },
+    "immutable": {
+      "version": "3.7.6",
+      "from": "immutable@>=3.7.6 <4.0.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz"
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "from": "imurmurhash@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
     },
     "indent-string": {
       "version": "2.1.0",
-      "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "from": "indent-string@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "dependencies": {
         "repeating": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
+          "from": "repeating@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz"
         }
       }
     },
     "infinity-agent": {
       "version": "2.0.3",
-      "from": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz",
+      "from": "infinity-agent@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz"
     },
     "inflection": {
-      "version": "1.7.2",
-      "from": "https://registry.npmjs.org/inflection/-/inflection-1.7.2.tgz",
-      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.7.2.tgz"
+      "version": "1.8.0",
+      "from": "inflection@>=1.6.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.8.0.tgz"
     },
     "inflight": {
       "version": "1.0.4",
-      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+      "from": "inflight@>=1.0.4 <2.0.0",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz"
     },
     "inherits": {
       "version": "2.0.1",
-      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "from": "inherits@>=2.0.1 <2.1.0",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
     },
     "ini": {
       "version": "1.3.4",
-      "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+      "from": "ini@>=1.3.0 <1.4.0",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
     },
     "inquirer": {
-      "version": "0.11.0",
-      "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.11.0.tgz",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.11.0.tgz"
+      "version": "0.11.4",
+      "from": "inquirer@>=0.11.0 <0.12.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.11.4.tgz"
     },
     "interpret": {
-      "version": "0.6.6",
-      "from": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
+      "version": "1.0.0",
+      "from": "interpret@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.0.tgz"
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "from": "invert-kv@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
     },
     "is-absolute": {
       "version": "0.1.7",
-      "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+      "from": "is-absolute@>=0.1.7 <0.2.0",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz"
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "from": "is-arrayish@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
     },
     "is-binary-path": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "from": "is-binary-path@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz"
     },
     "is-buffer": {
-      "version": "1.1.0",
-      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+      "version": "1.1.2",
+      "from": "is-buffer@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "from": "is-builtin-module@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
     },
     "is-dotfile": {
       "version": "1.0.2",
-      "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
+      "from": "is-dotfile@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
     },
     "is-equal-shallow": {
       "version": "0.1.3",
-      "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "from": "is-equal-shallow@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
     },
     "is-extendable": {
       "version": "0.1.1",
-      "from": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "from": "is-extendable@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
     },
     "is-extglob": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "from": "is-extglob@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
     },
     "is-finite": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+      "from": "is-finite@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
     },
     "is-generator": {
       "version": "1.0.2",
-      "from": "https://registry.npmjs.org/is-generator/-/is-generator-1.0.2.tgz",
+      "from": "is-generator@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-generator/-/is-generator-1.0.2.tgz"
     },
     "is-glob": {
       "version": "2.0.1",
-      "from": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "from": "is-glob@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
     },
     "is-my-json-valid": {
-      "version": "2.12.3",
-      "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz"
+      "version": "2.12.4",
+      "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz"
     },
     "is-npm": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+      "from": "is-npm@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
     },
     "is-number": {
-      "version": "1.1.2",
-      "from": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
+      "version": "2.1.0",
+      "from": "is-number@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
     },
     "is-path-cwd": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "from": "is-path-cwd@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
     },
     "is-path-in-cwd": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz"
     },
     "is-path-inside": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+      "from": "is-path-inside@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
     },
     "is-primitive": {
       "version": "2.0.0",
-      "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "from": "is-primitive@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
     },
     "is-property": {
       "version": "1.0.2",
-      "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "from": "is-property@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
     },
     "is-redirect": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "from": "is-redirect@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
     },
     "is-relative": {
       "version": "0.1.3",
-      "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+      "from": "is-relative@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
     },
     "is-resolvable": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+      "from": "is-resolvable@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz"
     },
     "is-stream": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz",
+      "from": "is-stream@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "from": "is-typedarray@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
     },
     "is-utf8": {
-      "version": "0.2.0",
-      "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
+      "version": "0.2.1",
+      "from": "is-utf8@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
     },
     "isarray": {
       "version": "0.0.1",
-      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "from": "isarray@0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
     },
+    "isexe": {
+      "version": "1.1.2",
+      "from": "isexe@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
+    },
     "isobject": {
-      "version": "1.0.2",
-      "from": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
+      "version": "2.0.0",
+      "from": "isobject@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz"
     },
     "isstream": {
       "version": "0.1.2",
-      "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "from": "isstream@>=0.1.2 <0.2.0",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
     },
     "jade": {
       "version": "0.26.3",
-      "from": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "from": "jade@0.26.3",
       "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
       "dependencies": {
         "commander": {
           "version": "0.6.1",
-          "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "from": "commander@0.6.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
         },
         "mkdirp": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "from": "mkdirp@0.3.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
         }
       }
     },
     "jodid25519": {
       "version": "1.0.2",
-      "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+      "from": "jodid25519@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
     },
     "js-beautify": {
-      "version": "1.5.10",
-      "from": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.5.10.tgz",
-      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.5.10.tgz",
+      "version": "1.6.2",
+      "from": "js-beautify@>=1.5.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.2.tgz",
       "dependencies": {
         "nopt": {
           "version": "3.0.6",
-          "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "from": "nopt@>=3.0.1 <3.1.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
         }
       }
     },
     "js-yaml": {
       "version": "3.0.1",
-      "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.1.tgz",
+      "from": "js-yaml@3.0.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.1.tgz",
       "dependencies": {
         "argparse": {
           "version": "0.1.16",
-          "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+          "from": "argparse@>=0.1.11 <0.2.0",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz"
         },
         "underscore": {
           "version": "1.7.0",
-          "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+          "from": "underscore@>=1.7.0 <1.8.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
         }
       }
     },
     "jsbn": {
       "version": "0.1.0",
-      "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+      "from": "jsbn@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
     },
     "json-schema": {
@@ -2118,1264 +1445,1268 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
     },
     "json-stable-stringify": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.0.tgz"
+      "version": "1.0.1",
+      "from": "json-stable-stringify@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "from": "json-stringify-safe@>=5.0.1 <5.1.0",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
     },
     "jsonfile": {
       "version": "2.2.3",
-      "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz",
+      "from": "jsonfile@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz"
     },
     "jsonify": {
       "version": "0.0.0",
-      "from": "jsonify@0.0.0",
+      "from": "jsonify@>=0.0.0 <0.1.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
     },
     "jsonpointer": {
       "version": "2.0.0",
-      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+      "from": "jsonpointer@2.0.0",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
     },
     "jsprim": {
       "version": "1.2.2",
-      "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
+      "from": "jsprim@>=1.2.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
     },
     "keygrip": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.1.tgz",
+      "from": "keygrip@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.1.tgz"
     },
     "kind-of": {
-      "version": "2.0.1",
-      "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz"
+      "version": "3.0.2",
+      "from": "kind-of@>=3.0.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz"
+    },
+    "klaw": {
+      "version": "1.1.3",
+      "from": "klaw@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.1.3.tgz"
     },
     "koa": {
       "version": "1.1.2",
-      "from": "https://registry.npmjs.org/koa/-/koa-1.1.2.tgz",
+      "from": "koa@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/koa/-/koa-1.1.2.tgz"
     },
     "koa-compose": {
       "version": "2.3.0",
-      "from": "https://registry.npmjs.org/koa-compose/-/koa-compose-2.3.0.tgz",
+      "from": "koa-compose@>=2.3.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-2.3.0.tgz"
     },
     "koa-compress": {
-      "version": "1.0.8",
-      "from": "https://registry.npmjs.org/koa-compress/-/koa-compress-1.0.8.tgz",
-      "resolved": "https://registry.npmjs.org/koa-compress/-/koa-compress-1.0.8.tgz"
+      "version": "1.0.9",
+      "from": "koa-compress@>=1.0.6 <2.0.0",
+      "resolved": "https://registry.npmjs.org/koa-compress/-/koa-compress-1.0.9.tgz",
+      "dependencies": {
+        "bytes": {
+          "version": "2.3.0",
+          "from": "bytes@>=2.3.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz"
+        }
+      }
     },
     "koa-cors": {
       "version": "0.0.16",
-      "from": "https://registry.npmjs.org/koa-cors/-/koa-cors-0.0.16.tgz",
+      "from": "koa-cors@0.0.16",
       "resolved": "https://registry.npmjs.org/koa-cors/-/koa-cors-0.0.16.tgz"
     },
     "koa-is-json": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/koa-is-json/-/koa-is-json-1.0.0.tgz",
+      "from": "koa-is-json@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/koa-is-json/-/koa-is-json-1.0.0.tgz"
     },
     "koa-mag": {
       "version": "1.1.0",
-      "from": "https://registry.npmjs.org/koa-mag/-/koa-mag-1.1.0.tgz",
+      "from": "koa-mag@>=1.0.4 <2.0.0",
       "resolved": "https://registry.npmjs.org/koa-mag/-/koa-mag-1.1.0.tgz"
     },
     "koa-passport": {
       "version": "1.2.0",
-      "from": "https://registry.npmjs.org/koa-passport/-/koa-passport-1.2.0.tgz",
+      "from": "koa-passport@>=1.1.6 <2.0.0",
       "resolved": "https://registry.npmjs.org/koa-passport/-/koa-passport-1.2.0.tgz"
     },
     "koa-router": {
-      "version": "5.2.3",
-      "from": "https://registry.npmjs.org/koa-router/-/koa-router-5.2.3.tgz",
-      "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-5.2.3.tgz"
+      "version": "5.4.0",
+      "from": "koa-router@>=5.1.2 <6.0.0",
+      "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-5.4.0.tgz"
     },
     "koa-send": {
       "version": "2.0.2",
-      "from": "https://registry.npmjs.org/koa-send/-/koa-send-2.0.2.tgz",
+      "from": "koa-send@>=2.0.1 <2.1.0",
       "resolved": "https://registry.npmjs.org/koa-send/-/koa-send-2.0.2.tgz"
     },
     "koa-static": {
       "version": "1.5.2",
-      "from": "https://registry.npmjs.org/koa-static/-/koa-static-1.5.2.tgz",
+      "from": "koa-static@>=1.4.5 <2.0.0",
       "resolved": "https://registry.npmjs.org/koa-static/-/koa-static-1.5.2.tgz"
     },
     "latest-version": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz",
+      "from": "latest-version@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.1.tgz"
     },
     "lazy-cache": {
-      "version": "0.2.4",
-      "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.4.tgz",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.4.tgz"
+      "version": "1.0.3",
+      "from": "lazy-cache@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "from": "lcid@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
     },
     "lcov-parse": {
       "version": "0.0.6",
-      "from": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.6.tgz",
+      "from": "lcov-parse@0.0.6",
       "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.6.tgz"
     },
     "levn": {
       "version": "0.2.5",
-      "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+      "from": "levn@>=0.2.5 <0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
     },
     "liftoff": {
       "version": "2.2.0",
-      "from": "https://registry.npmjs.org/liftoff/-/liftoff-2.2.0.tgz",
+      "from": "liftoff@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.2.0.tgz",
       "dependencies": {
         "extend": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
+          "from": "extend@>=2.0.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
-        },
-        "findup-sync": {
-          "version": "0.3.0",
-          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz"
-        },
-        "glob": {
-          "version": "5.0.15",
-          "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
         }
       }
     },
     "linkify-it": {
       "version": "1.2.0",
-      "from": "https://registry.npmjs.org/linkify-it/-/linkify-it-1.2.0.tgz",
+      "from": "linkify-it@>=1.2.0 <1.3.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-1.2.0.tgz"
     },
     "load-json-file": {
       "version": "1.1.0",
-      "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "dependencies": {
-        "pinkie-promise": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
-        },
-        "pinkie": {
-          "version": "2.0.1",
-          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
-        }
-      }
+      "from": "load-json-file@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz"
     },
     "lodash": {
       "version": "3.10.1",
-      "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "from": "lodash@>=3.5.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
     },
     "lodash._arraycopy": {
       "version": "3.0.0",
-      "from": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+      "from": "lodash._arraycopy@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
     },
     "lodash._arrayeach": {
       "version": "3.0.0",
-      "from": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+      "from": "lodash._arrayeach@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
     },
     "lodash._arraymap": {
       "version": "3.0.0",
-      "from": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz",
+      "from": "lodash._arraymap@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz"
     },
     "lodash._baseassign": {
       "version": "3.2.0",
-      "from": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "from": "lodash._baseassign@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz"
     },
     "lodash._baseclone": {
       "version": "3.3.0",
-      "from": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+      "from": "lodash._baseclone@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz"
     },
     "lodash._basecopy": {
       "version": "3.0.1",
-      "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
     },
     "lodash._basedifference": {
       "version": "3.0.3",
-      "from": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
+      "from": "lodash._basedifference@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz"
     },
     "lodash._baseflatten": {
       "version": "3.1.4",
-      "from": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+      "from": "lodash._baseflatten@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz"
     },
     "lodash._basefor": {
-      "version": "3.0.2",
-      "from": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
+      "version": "3.0.3",
+      "from": "lodash._basefor@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz"
     },
     "lodash._baseindexof": {
       "version": "3.1.0",
-      "from": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+      "from": "lodash._baseindexof@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz"
     },
     "lodash._basetostring": {
       "version": "3.0.1",
-      "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+      "from": "lodash._basetostring@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
     },
     "lodash._basevalues": {
       "version": "3.0.0",
-      "from": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+      "from": "lodash._basevalues@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
     },
     "lodash._bindcallback": {
       "version": "3.0.1",
-      "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
     },
     "lodash._cacheindexof": {
       "version": "3.0.2",
-      "from": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+      "from": "lodash._cacheindexof@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz"
     },
     "lodash._createassigner": {
       "version": "3.1.1",
-      "from": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+      "from": "lodash._createassigner@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz"
     },
     "lodash._createcache": {
       "version": "3.1.2",
-      "from": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+      "from": "lodash._createcache@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz"
     },
     "lodash._getnative": {
       "version": "3.9.1",
-      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "from": "lodash._getnative@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
-      "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
     },
     "lodash._pickbyarray": {
       "version": "3.0.2",
-      "from": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
+      "from": "lodash._pickbyarray@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz"
     },
     "lodash._pickbycallback": {
       "version": "3.0.0",
-      "from": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+      "from": "lodash._pickbycallback@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz"
     },
     "lodash._reescape": {
       "version": "3.0.0",
-      "from": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+      "from": "lodash._reescape@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
     },
     "lodash._reevaluate": {
       "version": "3.0.0",
-      "from": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+      "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
-      "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+    },
+    "lodash._root": {
+      "version": "3.0.1",
+      "from": "lodash._root@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
     },
     "lodash.assign": {
       "version": "3.2.0",
-      "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+      "from": "lodash.assign@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz"
     },
     "lodash.clonedeep": {
       "version": "3.0.2",
-      "from": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+      "from": "lodash.clonedeep@>=3.0.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz"
     },
     "lodash.defaults": {
       "version": "3.1.2",
-      "from": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
+      "from": "lodash.defaults@>=3.1.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz"
     },
     "lodash.escape": {
-      "version": "3.0.0",
-      "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+      "version": "3.2.0",
+      "from": "lodash.escape@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz"
     },
     "lodash.isarguments": {
-      "version": "3.0.4",
-      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+      "version": "3.0.7",
+      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz"
     },
     "lodash.isarray": {
       "version": "3.0.4",
-      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "from": "lodash.isarray@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
     },
     "lodash.isplainobject": {
       "version": "3.2.0",
-      "from": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+      "from": "lodash.isplainobject@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz"
     },
     "lodash.istypedarray": {
-      "version": "3.0.2",
-      "from": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.2.tgz"
+      "version": "3.0.5",
+      "from": "lodash.istypedarray@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.5.tgz"
     },
     "lodash.keys": {
       "version": "3.1.2",
-      "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "from": "lodash.keys@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
     },
     "lodash.keysin": {
       "version": "3.0.8",
-      "from": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+      "from": "lodash.keysin@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz"
     },
     "lodash.merge": {
       "version": "3.3.2",
-      "from": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
+      "from": "lodash.merge@>=3.3.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz"
     },
     "lodash.omit": {
       "version": "3.1.0",
-      "from": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
+      "from": "lodash.omit@>=3.1.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz"
     },
     "lodash.restparam": {
       "version": "3.6.1",
-      "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "from": "lodash.restparam@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
     },
     "lodash.template": {
       "version": "3.6.2",
-      "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+      "from": "lodash.template@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz"
     },
     "lodash.templatesettings": {
-      "version": "3.1.0",
-      "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+      "version": "3.1.1",
+      "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
     },
     "lodash.toplainobject": {
       "version": "3.0.0",
-      "from": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+      "from": "lodash.toplainobject@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz"
     },
     "log-driver": {
       "version": "1.2.4",
-      "from": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.4.tgz",
+      "from": "log-driver@1.2.4",
       "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.4.tgz"
     },
     "lolex": {
       "version": "1.3.2",
-      "from": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "from": "lolex@1.3.2",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz"
     },
     "longest": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "from": "longest@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
     },
     "loud-rejection": {
-      "version": "1.2.0",
-      "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz"
+      "version": "1.2.1",
+      "from": "loud-rejection@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.1.tgz"
     },
     "lowercase-keys": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+      "from": "lowercase-keys@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
     },
     "lru-cache": {
-      "version": "2.7.0",
-      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+      "version": "2.7.3",
+      "from": "lru-cache@>=2.6.5 <3.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
     },
     "lru-queue": {
       "version": "0.1.0",
-      "from": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "from": "lru-queue@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
     },
     "mag": {
       "version": "0.9.1",
-      "from": "https://registry.npmjs.org/mag/-/mag-0.9.1.tgz",
+      "from": "mag@>=0.9.1 <0.10.0",
       "resolved": "https://registry.npmjs.org/mag/-/mag-0.9.1.tgz"
     },
     "mag-colored-output": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/mag-colored-output/-/mag-colored-output-1.0.1.tgz",
+      "from": "mag-colored-output@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/mag-colored-output/-/mag-colored-output-1.0.1.tgz"
     },
     "mag-fallback": {
       "version": "0.9.1",
-      "from": "https://registry.npmjs.org/mag-fallback/-/mag-fallback-0.9.1.tgz",
+      "from": "mag-fallback@>=0.9.0 <0.10.0",
       "resolved": "https://registry.npmjs.org/mag-fallback/-/mag-fallback-0.9.1.tgz",
       "dependencies": {
         "readable-stream": {
           "version": "1.1.13",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+          "from": "readable-stream@>=1.1.13 <2.0.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
         }
       }
     },
     "mag-format-message": {
       "version": "0.1.1",
-      "from": "https://registry.npmjs.org/mag-format-message/-/mag-format-message-0.1.1.tgz",
+      "from": "mag-format-message@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/mag-format-message/-/mag-format-message-0.1.1.tgz",
       "dependencies": {
         "readable-stream": {
           "version": "1.1.13",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+          "from": "readable-stream@>=1.1.12 <2.0.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
         }
       }
     },
     "mag-hub": {
       "version": "0.1.1",
-      "from": "https://registry.npmjs.org/mag-hub/-/mag-hub-0.1.1.tgz",
+      "from": "mag-hub@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/mag-hub/-/mag-hub-0.1.1.tgz",
       "dependencies": {
         "readable-stream": {
           "version": "1.1.13",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+          "from": "readable-stream@>=1.1.12 <2.0.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
         }
       }
     },
     "mag-logger-facade": {
       "version": "0.9.0",
-      "from": "https://registry.npmjs.org/mag-logger-facade/-/mag-logger-facade-0.9.0.tgz",
+      "from": "mag-logger-facade@0.9.0",
       "resolved": "https://registry.npmjs.org/mag-logger-facade/-/mag-logger-facade-0.9.0.tgz"
     },
     "mag-stream": {
       "version": "0.9.0",
-      "from": "https://registry.npmjs.org/mag-stream/-/mag-stream-0.9.0.tgz",
+      "from": "mag-stream@>=0.9.0 <0.10.0",
       "resolved": "https://registry.npmjs.org/mag-stream/-/mag-stream-0.9.0.tgz"
     },
     "map-obj": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "from": "map-obj@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
     },
     "map-stream": {
       "version": "0.1.0",
-      "from": "map-stream@0.1.0",
+      "from": "map-stream@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
+    },
+    "markdown-it": {
+      "version": "5.1.0",
+      "from": "markdown-it@>=5.0.2 <6.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-5.1.0.tgz"
     },
     "mdurl": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "from": "mdurl@>=1.0.1 <1.1.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz"
     },
     "media-typer": {
       "version": "0.3.0",
-      "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "from": "media-typer@0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
     },
     "memoizee": {
       "version": "0.3.9",
-      "from": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.9.tgz",
+      "from": "memoizee@>=0.3.8 <0.4.0",
       "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.9.tgz"
     },
     "meow": {
-      "version": "3.6.0",
-      "from": "https://registry.npmjs.org/meow/-/meow-3.6.0.tgz",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.6.0.tgz",
+      "version": "3.7.0",
+      "from": "meow@>=3.3.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "from": "minimist@>=1.1.3 <2.0.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         }
       }
     },
     "methods": {
-      "version": "1.1.1",
-      "from": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz"
+      "version": "1.1.2",
+      "from": "methods@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
     },
     "micromatch": {
-      "version": "2.3.2",
-      "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.2.tgz",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.2.tgz"
+      "version": "2.3.7",
+      "from": "micromatch@>=2.1.5 <3.0.0",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz"
+    },
+    "mime": {
+      "version": "1.3.4",
+      "from": "mime@1.3.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
     },
     "mime-db": {
-      "version": "1.19.0",
-      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+      "version": "1.22.0",
+      "from": "mime-db@>=1.22.0 <1.23.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
     },
     "mime-types": {
-      "version": "2.1.7",
-      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz"
+      "version": "2.1.10",
+      "from": "mime-types@>=2.1.7 <2.2.0",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz"
     },
     "minimatch": {
       "version": "3.0.0",
-      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+      "from": "minimatch@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
     },
     "minimist": {
       "version": "0.0.8",
-      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "from": "minimist@0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
     },
     "mkdirp": {
       "version": "0.5.1",
-      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "from": "mkdirp@>=0.5.0 <0.6.0",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
     },
     "moment": {
-      "version": "2.10.6",
-      "from": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
+      "version": "2.11.2",
+      "from": "moment@>=2.10.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz"
     },
     "moment-timezone": {
-      "version": "0.4.1",
-      "from": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.1.tgz",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.1.tgz"
+      "version": "0.5.0",
+      "from": "moment-timezone@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.0.tgz"
     },
     "ms": {
       "version": "0.7.1",
-      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "from": "ms@0.7.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
     },
     "multipipe": {
       "version": "0.1.2",
-      "from": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+      "from": "multipipe@>=0.1.2 <0.2.0",
       "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz"
     },
     "mute-stream": {
       "version": "0.0.5",
-      "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+      "from": "mute-stream@0.0.5",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
     },
     "mysql": {
-      "version": "2.9.0",
-      "from": "https://registry.npmjs.org/mysql/-/mysql-2.9.0.tgz",
-      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.9.0.tgz",
+      "version": "2.10.2",
+      "from": "mysql@>=2.9.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.10.2.tgz",
       "dependencies": {
         "readable-stream": {
           "version": "1.1.13",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+          "from": "readable-stream@>=1.1.13 <1.2.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
         }
       }
     },
     "mz": {
-      "version": "2.1.0",
-      "from": "https://registry.npmjs.org/mz/-/mz-2.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.1.0.tgz"
+      "version": "2.3.1",
+      "from": "mz@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.3.1.tgz"
     },
     "nan": {
-      "version": "2.1.0",
-      "from": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
+      "version": "2.0.5",
+      "from": "nan@2.0.5",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.5.tgz"
     },
     "native-or-bluebird": {
       "version": "1.2.0",
-      "from": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.2.0.tgz",
+      "from": "native-or-bluebird@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.2.0.tgz"
     },
     "negotiator": {
       "version": "0.6.0",
-      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.0.tgz",
+      "from": "negotiator@0.6.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.0.tgz"
     },
     "nested-error-stacks": {
-      "version": "1.0.1",
-      "from": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.1.tgz"
+      "version": "1.0.2",
+      "from": "nested-error-stacks@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.2.tgz"
     },
     "next-tick": {
       "version": "0.2.2",
-      "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
+      "from": "next-tick@>=0.2.2 <0.3.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
     },
     "node-uuid": {
       "version": "1.4.7",
-      "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+      "from": "node-uuid@>=1.4.7 <1.5.0",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
     },
     "nodemon": {
       "version": "1.8.1",
-      "from": "https://registry.npmjs.org/nodemon/-/nodemon-1.8.1.tgz",
+      "from": "nodemon@>=1.3.5 <2.0.0",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.8.1.tgz"
     },
     "nomnom": {
       "version": "1.8.1",
-      "from": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+      "from": "nomnom@>=1.8.1 <1.9.0",
       "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
       "dependencies": {
-        "chalk": {
-          "version": "0.4.0",
-          "from": "chalk@0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz"
-        },
         "ansi-styles": {
           "version": "1.0.0",
-          "from": "ansi-styles@1.0.0",
+          "from": "ansi-styles@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+        },
+        "chalk": {
+          "version": "0.4.0",
+          "from": "chalk@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz"
         },
         "strip-ansi": {
           "version": "0.1.1",
-          "from": "strip-ansi@0.1.1",
+          "from": "strip-ansi@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
         }
       }
     },
     "nopt": {
       "version": "1.0.10",
-      "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "from": "nopt@>=1.0.10 <1.1.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
     },
     "normalize-package-data": {
       "version": "2.3.5",
-      "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+      "from": "normalize-package-data@>=2.3.4 <3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
     },
     "normalize-path": {
       "version": "2.0.1",
-      "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
+      "from": "normalize-path@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
     },
     "number-is-nan": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+      "from": "number-is-nan@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
     },
     "oauth-sign": {
-      "version": "0.8.0",
-      "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+      "version": "0.8.1",
+      "from": "oauth-sign@>=0.8.0 <0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
     },
     "object-assign": {
       "version": "4.0.1",
-      "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+      "from": "object-assign@>=4.0.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
     },
     "object.omit": {
       "version": "2.0.0",
-      "from": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
+      "from": "object.omit@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz"
     },
     "on-finished": {
       "version": "2.3.0",
-      "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "from": "on-finished@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz"
     },
     "once": {
-      "version": "1.3.2",
-      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz"
+      "version": "1.3.3",
+      "from": "once@>=1.3.0 <1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
     },
     "onetime": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
+      "version": "1.1.0",
+      "from": "onetime@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
     },
     "only": {
       "version": "0.0.2",
-      "from": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
+      "from": "only@0.0.2",
       "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz"
     },
     "optimist": {
       "version": "0.6.1",
-      "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "from": "optimist@>=0.6.1 <0.7.0",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz"
     },
     "optionator": {
       "version": "0.6.0",
-      "from": "https://registry.npmjs.org/optionator/-/optionator-0.6.0.tgz",
+      "from": "optionator@>=0.6.0 <0.7.0",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.6.0.tgz"
     },
     "orchestrator": {
       "version": "0.3.7",
-      "from": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
+      "from": "orchestrator@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
       "dependencies": {
         "end-of-stream": {
           "version": "0.1.5",
-          "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+          "from": "end-of-stream@>=0.1.5 <0.2.0",
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz"
         }
       }
     },
     "ordered-read-streams": {
       "version": "0.1.0",
-      "from": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
+      "from": "ordered-read-streams@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
     },
     "os-homedir": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+      "from": "os-homedir@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "from": "os-locale@>=1.4.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
     },
     "os-tmpdir": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+      "from": "os-tmpdir@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
     },
     "osenv": {
       "version": "0.1.3",
-      "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+      "from": "osenv@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz"
     },
     "package-json": {
       "version": "1.2.0",
-      "from": "https://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz",
+      "from": "package-json@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-1.2.0.tgz"
     },
     "packet-reader": {
       "version": "0.2.0",
-      "from": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.2.0.tgz",
+      "from": "packet-reader@0.2.0",
       "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.2.0.tgz"
     },
     "parse-glob": {
       "version": "3.0.4",
-      "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "from": "parse-glob@>=3.0.4 <4.0.0",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
     },
     "parse-json": {
       "version": "2.2.0",
-      "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "from": "parse-json@>=2.2.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
     },
     "parseurl": {
-      "version": "1.3.0",
-      "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+      "version": "1.3.1",
+      "from": "parseurl@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
     },
     "passport": {
       "version": "0.3.2",
-      "from": "https://registry.npmjs.org/passport/-/passport-0.3.2.tgz",
+      "from": "passport@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.3.2.tgz"
     },
     "passport-anonymous": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/passport-anonymous/-/passport-anonymous-1.0.1.tgz",
+      "from": "passport-anonymous@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/passport-anonymous/-/passport-anonymous-1.0.1.tgz"
     },
     "passport-http": {
       "version": "0.3.0",
-      "from": "https://registry.npmjs.org/passport-http/-/passport-http-0.3.0.tgz",
+      "from": "passport-http@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/passport-http/-/passport-http-0.3.0.tgz"
     },
     "passport-http-signature": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/passport-http-signature/-/passport-http-signature-1.0.0.tgz",
+      "from": "passport-http-signature@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/passport-http-signature/-/passport-http-signature-1.0.0.tgz"
     },
     "passport-strategy": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "from": "passport-strategy@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz"
     },
     "passthrough-counter": {
       "version": "0.0.1",
-      "from": "https://registry.npmjs.org/passthrough-counter/-/passthrough-counter-0.0.1.tgz",
+      "from": "passthrough-counter@>=0.0.1 <0.1.0",
       "resolved": "https://registry.npmjs.org/passthrough-counter/-/passthrough-counter-0.0.1.tgz"
     },
     "path-exists": {
       "version": "2.1.0",
-      "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "dependencies": {
-        "pinkie-promise": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
-        },
-        "pinkie": {
-          "version": "2.0.1",
-          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
-        }
-      }
+      "from": "path-exists@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
     },
     "path-is-absolute": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+      "from": "path-is-absolute@1.0.0",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
     },
     "path-is-inside": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
+      "from": "path-is-inside@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
     },
     "path-to-regexp": {
       "version": "1.2.1",
-      "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.2.1.tgz",
+      "from": "path-to-regexp@>=1.2.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.2.1.tgz"
     },
     "path-type": {
       "version": "1.1.0",
-      "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "dependencies": {
-        "pinkie-promise": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
-        },
-        "pinkie": {
-          "version": "2.0.1",
-          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
-        }
-      }
+      "from": "path-type@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
     },
     "pause": {
       "version": "0.0.1",
-      "from": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "from": "pause@0.0.1",
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
     },
     "pause-stream": {
       "version": "0.0.11",
-      "from": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "from": "pause-stream@0.0.11",
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
     },
     "pg": {
-      "version": "4.4.3",
-      "from": "https://registry.npmjs.org/pg/-/pg-4.4.3.tgz",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-4.4.3.tgz",
+      "version": "4.4.6",
+      "from": "pg@>=4.4.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-4.4.6.tgz",
       "dependencies": {
         "semver": {
           "version": "4.3.6",
-          "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "from": "semver@>=4.1.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         }
       }
     },
     "pg-connection-string": {
       "version": "0.1.3",
-      "from": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
+      "from": "pg-connection-string@0.1.3",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz"
     },
     "pg-types": {
       "version": "1.10.0",
-      "from": "https://registry.npmjs.org/pg-types/-/pg-types-1.10.0.tgz",
+      "from": "pg-types@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.10.0.tgz"
     },
     "pgpass": {
       "version": "0.0.3",
-      "from": "https://registry.npmjs.org/pgpass/-/pgpass-0.0.3.tgz",
+      "from": "pgpass@0.0.3",
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-0.0.3.tgz"
     },
     "pify": {
       "version": "2.3.0",
-      "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "from": "pify@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
     },
     "pinkie": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+      "version": "2.0.4",
+      "from": "pinkie@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
     },
     "pinkie-promise": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz"
+      "version": "2.0.0",
+      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
     },
     "pkginfo": {
       "version": "0.3.1",
-      "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+      "from": "pkginfo@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
     },
     "postgres-array": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.0.tgz",
+      "from": "postgres-array@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.0.tgz"
     },
     "postgres-bytea": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "from": "postgres-bytea@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz"
     },
     "postgres-date": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.0.tgz"
+      "version": "1.0.1",
+      "from": "postgres-date@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.1.tgz"
     },
     "postgres-interval": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.0.0.tgz"
+      "version": "1.0.1",
+      "from": "postgres-interval@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.0.1.tgz"
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "from": "prelude-ls@>=1.1.1 <1.2.0",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
     },
     "prepend-http": {
       "version": "1.0.3",
-      "from": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz",
+      "from": "prepend-http@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz"
     },
     "preserve": {
       "version": "0.2.0",
-      "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "from": "preserve@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
     },
     "pretty-hrtime": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.1.tgz",
+      "from": "pretty-hrtime@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.1.tgz"
     },
     "priorityqueuejs": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/priorityqueuejs/-/priorityqueuejs-1.0.0.tgz",
+      "from": "priorityqueuejs@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/priorityqueuejs/-/priorityqueuejs-1.0.0.tgz"
     },
     "process-nextick-args": {
-      "version": "1.0.3",
-      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+      "version": "1.0.6",
+      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
     },
     "propagate": {
       "version": "0.3.1",
-      "from": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz",
+      "from": "propagate@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz"
     },
     "proto-list": {
       "version": "1.2.4",
-      "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "from": "proto-list@>=1.2.1 <1.3.0",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
     },
     "ps-tree": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.0.1.tgz",
+      "from": "ps-tree@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.0.1.tgz"
     },
     "qs": {
-      "version": "5.2.0",
-      "from": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+      "version": "6.0.2",
+      "from": "qs@>=6.0.2 <6.1.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
     },
     "randomatic": {
-      "version": "1.1.3",
-      "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.3.tgz",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.3.tgz",
-      "dependencies": {
-        "is-number": {
-          "version": "2.0.2",
-          "from": "https://registry.npmjs.org/is-number/-/is-number-2.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.0.2.tgz",
-          "dependencies": {
-            "kind-of": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
-            }
-          }
-        }
-      }
+      "version": "1.1.5",
+      "from": "randomatic@>=1.1.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
     },
     "raw-body": {
       "version": "1.3.4",
-      "from": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.4.tgz",
+      "from": "raw-body@>=1.3.3 <1.4.0",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.4.tgz"
     },
     "rc": {
-      "version": "1.1.5",
-      "from": "https://registry.npmjs.org/rc/-/rc-1.1.5.tgz",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.5.tgz",
+      "version": "1.1.6",
+      "from": "rc@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "from": "minimist@>=1.2.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         }
       }
     },
     "read-all-stream": {
-      "version": "3.0.1",
-      "from": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.0.1.tgz"
+      "version": "3.1.0",
+      "from": "read-all-stream@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz"
     },
     "read-json-sync": {
-      "version": "1.1.0",
-      "from": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.0.tgz",
-      "dependencies": {
-        "graceful-fs": {
-          "version": "3.0.8",
-          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-        }
-      }
+      "version": "1.1.1",
+      "from": "read-json-sync@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.1.tgz"
     },
     "read-pkg": {
       "version": "1.1.0",
-      "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "from": "read-pkg@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
     },
     "read-pkg-up": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "from": "read-pkg-up@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
     },
     "readable-stream": {
-      "version": "2.0.4",
-      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz"
+      "version": "2.0.5",
+      "from": "readable-stream@>=2.0.5 <2.1.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
     },
     "readdirp": {
       "version": "2.0.0",
-      "from": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
+      "from": "readdirp@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
       "dependencies": {
         "minimatch": {
           "version": "2.0.10",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "from": "minimatch@>=2.0.10 <3.0.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
         }
       }
     },
     "readline2": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "from": "readline2@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz"
     },
     "rechoir": {
       "version": "0.6.2",
-      "from": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "from": "rechoir@>=0.6.0 <0.7.0",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
     },
     "redefine": {
       "version": "0.2.1",
-      "from": "https://registry.npmjs.org/redefine/-/redefine-0.2.1.tgz",
+      "from": "redefine@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/redefine/-/redefine-0.2.1.tgz"
     },
     "redent": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "from": "redent@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz"
     },
     "reduce-component": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
+      "from": "reduce-component@1.0.1",
       "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz"
     },
     "regex-cache": {
       "version": "0.4.2",
-      "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
+      "from": "regex-cache@>=0.4.2 <0.5.0",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz"
     },
     "registry-url": {
       "version": "3.0.3",
-      "from": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz",
+      "from": "registry-url@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz"
     },
     "repeat-element": {
       "version": "1.1.2",
-      "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "from": "repeat-element@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
     },
     "repeat-string": {
       "version": "1.5.2",
-      "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+      "from": "repeat-string@>=1.5.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
     },
     "repeating": {
       "version": "1.1.3",
-      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+      "from": "repeating@>=1.1.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
     },
     "replace-ext": {
       "version": "0.0.1",
-      "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+      "from": "replace-ext@0.0.1",
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
     },
     "request": {
-      "version": "2.67.0",
-      "from": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz"
+      "version": "2.69.0",
+      "from": "request@*",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz"
     },
     "resolve": {
-      "version": "1.1.6",
-      "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+      "version": "1.1.7",
+      "from": "resolve@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
     },
     "resolve-path": {
       "version": "1.3.0",
-      "from": "https://registry.npmjs.org/resolve-path/-/resolve-path-1.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/resolve-path/-/resolve-path-1.3.0.tgz"
+      "from": "resolve-path@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-path/-/resolve-path-1.3.0.tgz",
+      "dependencies": {
+        "http-errors": {
+          "version": "1.3.1",
+          "from": "http-errors@>=1.3.1 <1.4.0",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
+        }
+      }
     },
     "restore-cursor": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "from": "restore-cursor@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
+    },
+    "retry-as-promised": {
+      "version": "2.0.1",
+      "from": "retry-as-promised@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-2.0.1.tgz"
     },
     "right-align": {
       "version": "0.1.3",
-      "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "from": "right-align@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
     },
     "rimraf": {
-      "version": "2.4.4",
-      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.4.tgz",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.4.tgz",
+      "version": "2.5.2",
+      "from": "rimraf@>=2.2.8 <3.0.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
       "dependencies": {
         "glob": {
-          "version": "5.0.15",
-          "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
+          "version": "7.0.0",
+          "from": "glob@>=7.0.0 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.0.tgz"
         }
       }
     },
     "run-async": {
       "version": "0.1.0",
-      "from": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "from": "run-async@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz"
     },
     "rx-lite": {
       "version": "3.1.2",
-      "from": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "from": "rx-lite@>=3.1.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
     },
     "samsam": {
       "version": "1.1.2",
-      "from": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+      "from": "samsam@1.1.2",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
     },
     "semver": {
       "version": "5.1.0",
-      "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+      "from": "semver@>=5.0.3 <6.0.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
     },
     "semver-diff": {
       "version": "2.1.0",
-      "from": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "from": "semver-diff@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz"
     },
     "sequelize": {
-      "version": "3.14.0",
-      "from": "https://registry.npmjs.org/sequelize/-/sequelize-3.14.0.tgz",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-3.14.0.tgz",
+      "version": "3.19.2",
+      "from": "sequelize@>=3.6.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-3.19.2.tgz",
       "dependencies": {
         "generic-pool": {
-          "version": "2.2.1",
-          "from": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.2.1.tgz"
+          "version": "2.4.0",
+          "from": "generic-pool@2.4.0",
+          "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.0.tgz"
+        },
+        "lodash": {
+          "version": "4.5.0",
+          "from": "lodash@>=4.1.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.5.0.tgz"
         }
       }
     },
     "sequelize-cli": {
-      "version": "2.1.1",
-      "from": "https://registry.npmjs.org/sequelize-cli/-/sequelize-cli-2.1.1.tgz",
-      "resolved": "https://registry.npmjs.org/sequelize-cli/-/sequelize-cli-2.1.1.tgz",
+      "version": "2.3.1",
+      "from": "sequelize-cli@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/sequelize-cli/-/sequelize-cli-2.3.1.tgz",
       "dependencies": {
-        "bluebird": {
-          "version": "2.10.2",
-          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+        "lodash": {
+          "version": "4.5.0",
+          "from": "lodash@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.5.0.tgz"
         }
       }
     },
     "sequelize-json": {
       "version": "2.1.2",
-      "from": "https://registry.npmjs.org/sequelize-json/-/sequelize-json-2.1.2.tgz",
+      "from": "sequelize-json@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/sequelize-json/-/sequelize-json-2.1.2.tgz"
     },
     "sequencify": {
       "version": "0.0.7",
-      "from": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
+      "from": "sequencify@>=0.0.7 <0.1.0",
       "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz"
     },
     "shelljs": {
       "version": "0.5.3",
-      "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
+      "from": "shelljs@>=0.5.3 <0.6.0",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz"
     },
     "shimmer": {
       "version": "1.1.0",
-      "from": "https://registry.npmjs.org/shimmer/-/shimmer-1.1.0.tgz",
+      "from": "shimmer@1.1.0",
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.1.0.tgz"
     },
     "sigmund": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "from": "sigmund@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
     },
     "signal-exit": {
       "version": "2.1.2",
-      "from": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
+      "from": "signal-exit@>=2.1.2 <3.0.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
     },
     "slide": {
       "version": "1.1.6",
-      "from": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "from": "slide@>=1.1.5 <2.0.0",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
     },
     "sntp": {
       "version": "1.0.9",
-      "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "from": "sntp@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
     },
     "source-map": {
       "version": "0.4.4",
-      "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+      "from": "source-map@>=0.4.4 <0.5.0",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
     },
     "sparkles": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+      "from": "sparkles@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
     },
     "spdx-correct": {
       "version": "1.0.2",
-      "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "from": "spdx-correct@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
     },
     "spdx-exceptions": {
       "version": "1.0.4",
-      "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
+      "from": "spdx-exceptions@>=1.0.4 <2.0.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
     },
     "spdx-expression-parse": {
-      "version": "1.0.1",
-      "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.1.tgz"
+      "version": "1.0.2",
+      "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz"
     },
     "spdx-license-ids": {
-      "version": "1.1.0",
-      "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
+      "version": "1.2.0",
+      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
     },
     "split": {
       "version": "0.3.3",
-      "from": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "from": "split@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz"
     },
     "sprintf": {
       "version": "0.1.5",
-      "from": "https://registry.npmjs.org/sprintf/-/sprintf-0.1.5.tgz",
+      "from": "sprintf@0.1.5",
       "resolved": "https://registry.npmjs.org/sprintf/-/sprintf-0.1.5.tgz"
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "from": "sprintf-js@>=1.0.2 <1.1.0",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
     },
     "sqlite3": {
       "version": "3.1.1",
-      "from": "https://registry.npmjs.org/sqlite3/-/sqlite3-3.1.1.tgz",
+      "from": "sqlite3@>=3.1.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-3.1.1.tgz",
       "dependencies": {
+        "nan": {
+          "version": "2.1.0",
+          "from": "nan@>=2.1.0 <2.2.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
+        },
         "node-pre-gyp": {
           "version": "0.6.14",
           "from": "node-pre-gyp@~0.6.14",
           "dependencies": {
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@~0.5.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
             "nopt": {
               "version": "3.0.4",
               "from": "nopt@~3.0.1",
@@ -3418,6 +2749,11 @@
                           "from": "core-util-is@~1.0.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@2",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
                         "isarray": {
                           "version": "0.0.1",
                           "from": "isarray@0.0.1",
@@ -3427,11 +2763,6 @@
                           "version": "0.10.31",
                           "from": "string_decoder@~0.10.x",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@2",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -3523,11 +2854,43 @@
                 }
               }
             },
+            "rc": {
+              "version": "1.1.2",
+              "from": "rc@~1.1.0",
+              "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.2.tgz",
+              "dependencies": {
+                "deep-extend": {
+                  "version": "0.2.11",
+                  "from": "deep-extend@~0.2.5",
+                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                },
+                "ini": {
+                  "version": "1.3.4",
+                  "from": "ini@~1.3.0",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                },
+                "minimist": {
+                  "version": "1.2.0",
+                  "from": "minimist@^1.1.2",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                },
+                "strip-json-comments": {
+                  "version": "0.1.3",
+                  "from": "strip-json-comments@0.1.x",
+                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                }
+              }
+            },
             "request": {
               "version": "2.64.0",
               "from": "request@2.x",
               "resolved": "https://registry.npmjs.org/request/-/request-2.64.0.tgz",
               "dependencies": {
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@~0.5.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
                 "bl": {
                   "version": "1.0.0",
                   "from": "bl@~1.0.0",
@@ -3577,6 +2940,18 @@
                   "from": "caseless@~0.11.0",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                 },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "from": "combined-stream@~1.0.1",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "from": "delayed-stream@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                    }
+                  }
+                },
                 "extend": {
                   "version": "3.0.0",
                   "from": "extend@~3.0.0",
@@ -3598,124 +2973,6 @@
                       "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
                     }
                   }
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "from": "json-stringify-safe@~5.0.0",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-                },
-                "mime-types": {
-                  "version": "2.1.7",
-                  "from": "mime-types@~2.1.2",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.19.0",
-                      "from": "mime-db@~1.19.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
-                    }
-                  }
-                },
-                "node-uuid": {
-                  "version": "1.4.3",
-                  "from": "node-uuid@~1.4.0",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
-                },
-                "qs": {
-                  "version": "5.1.0",
-                  "from": "qs@~5.1.0",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.1",
-                  "from": "tunnel-agent@~0.4.0",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
-                },
-                "tough-cookie": {
-                  "version": "2.1.0",
-                  "from": "tough-cookie@>=0.12.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.1.0.tgz"
-                },
-                "http-signature": {
-                  "version": "0.11.0",
-                  "from": "http-signature@~0.11.0",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.1.5",
-                      "from": "assert-plus@^0.1.5",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                    },
-                    "asn1": {
-                      "version": "0.1.11",
-                      "from": "asn1@0.1.11",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                    },
-                    "ctype": {
-                      "version": "0.5.3",
-                      "from": "ctype@0.5.3",
-                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-                    }
-                  }
-                },
-                "oauth-sign": {
-                  "version": "0.8.0",
-                  "from": "oauth-sign@~0.8.0",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
-                },
-                "hawk": {
-                  "version": "3.1.0",
-                  "from": "hawk@~3.1.0",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
-                  "dependencies": {
-                    "hoek": {
-                      "version": "2.16.3",
-                      "from": "hoek@2.x.x",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                    },
-                    "boom": {
-                      "version": "2.9.0",
-                      "from": "boom@^2.8.x",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.9.0.tgz"
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5",
-                      "from": "cryptiles@2.x.x",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                    },
-                    "sntp": {
-                      "version": "1.0.9",
-                      "from": "sntp@1.x.x",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                    }
-                  }
-                },
-                "aws-sign2": {
-                  "version": "0.5.0",
-                  "from": "aws-sign2@~0.5.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-                },
-                "stringstream": {
-                  "version": "0.0.4",
-                  "from": "stringstream@~0.0.4",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
-                },
-                "combined-stream": {
-                  "version": "1.0.5",
-                  "from": "combined-stream@~1.0.1",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "1.0.0",
-                      "from": "delayed-stream@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                    }
-                  }
-                },
-                "isstream": {
-                  "version": "0.1.2",
-                  "from": "isstream@~0.1.1",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 },
                 "har-validator": {
                   "version": "1.8.0",
@@ -3820,201 +3077,107 @@
                       }
                     }
                   }
-                }
-              }
-            },
-            "semver": {
-              "version": "5.0.3",
-              "from": "semver@~5.0.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
-            },
-            "tar": {
-              "version": "2.2.1",
-              "from": "tar@~2.2.0",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-              "dependencies": {
-                "block-stream": {
-                  "version": "0.0.8",
-                  "from": "block-stream@*",
-                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
                 },
-                "fstream": {
-                  "version": "1.0.8",
-                  "from": "fstream@^1.0.2",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
+                "hawk": {
+                  "version": "3.1.0",
+                  "from": "hawk@~3.1.0",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
                   "dependencies": {
-                    "graceful-fs": {
-                      "version": "4.1.2",
-                      "from": "graceful-fs@^4.1.2",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                    "boom": {
+                      "version": "2.9.0",
+                      "from": "boom@^2.8.x",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.9.0.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "from": "cryptiles@2.x.x",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                    },
+                    "hoek": {
+                      "version": "2.16.3",
+                      "from": "hoek@2.x.x",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "sntp@1.x.x",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                     }
                   }
                 },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@2",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            },
-            "tar-pack": {
-              "version": "2.0.0",
-              "from": "tar-pack@~2.0.0",
-              "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-2.0.0.tgz",
-              "dependencies": {
-                "uid-number": {
-                  "version": "0.0.3",
-                  "from": "uid-number@0.0.3",
-                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
-                },
-                "once": {
-                  "version": "1.1.1",
-                  "from": "once@~1.1.1",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
-                },
-                "debug": {
-                  "version": "0.7.4",
-                  "from": "debug@~0.7.2",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-                },
-                "rimraf": {
-                  "version": "2.2.8",
-                  "from": "rimraf@~2.2.0",
-                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-                },
-                "fstream": {
-                  "version": "0.1.31",
-                  "from": "fstream@~0.1.22",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+                "http-signature": {
+                  "version": "0.11.0",
+                  "from": "http-signature@~0.11.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
                   "dependencies": {
-                    "graceful-fs": {
-                      "version": "3.0.8",
-                      "from": "graceful-fs@~3.0.2",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@~2.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@^0.1.5",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                     }
                   }
                 },
-                "tar": {
-                  "version": "0.1.20",
-                  "from": "tar@~0.1.17",
-                  "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "isstream@~0.1.1",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "json-stringify-safe@~5.0.0",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                },
+                "mime-types": {
+                  "version": "2.1.7",
+                  "from": "mime-types@~2.1.2",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
                   "dependencies": {
-                    "block-stream": {
-                      "version": "0.0.8",
-                      "from": "block-stream@*",
-                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@2",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    "mime-db": {
+                      "version": "1.19.0",
+                      "from": "mime-db@~1.19.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
                     }
                   }
                 },
-                "fstream-ignore": {
-                  "version": "0.0.7",
-                  "from": "fstream-ignore@0.0.7",
-                  "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.7.tgz",
-                  "dependencies": {
-                    "minimatch": {
-                      "version": "0.2.14",
-                      "from": "minimatch@~0.2.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "2.7.0",
-                          "from": "lru-cache@2",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
-                        },
-                        "sigmund": {
-                          "version": "1.0.1",
-                          "from": "sigmund@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "node-uuid@~1.4.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "readable-stream@~1.0.2",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
+                "oauth-sign": {
+                  "version": "0.8.0",
+                  "from": "oauth-sign@~0.8.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
                 },
-                "graceful-fs": {
-                  "version": "1.2.3",
-                  "from": "graceful-fs@1.2",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-                }
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "from": "mkdirp@~0.5.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                }
-              }
-            },
-            "rc": {
-              "version": "1.1.2",
-              "from": "rc@~1.1.0",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.2.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "1.2.0",
-                  "from": "minimist@^1.1.2",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                "qs": {
+                  "version": "5.1.0",
+                  "from": "qs@~5.1.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz"
                 },
-                "deep-extend": {
-                  "version": "0.2.11",
-                  "from": "deep-extend@~0.2.5",
-                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "stringstream@~0.0.4",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
-                "strip-json-comments": {
-                  "version": "0.1.3",
-                  "from": "strip-json-comments@0.1.x",
-                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                "tough-cookie": {
+                  "version": "2.1.0",
+                  "from": "tough-cookie@>=0.12.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.1.0.tgz"
                 },
-                "ini": {
-                  "version": "1.3.4",
-                  "from": "ini@~1.3.0",
-                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                "tunnel-agent": {
+                  "version": "0.4.1",
+                  "from": "tunnel-agent@~0.4.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
                 }
               }
             },
@@ -4089,501 +3252,677 @@
                   }
                 }
               }
+            },
+            "semver": {
+              "version": "5.0.3",
+              "from": "semver@~5.0.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
+            },
+            "tar": {
+              "version": "2.2.1",
+              "from": "tar@~2.2.0",
+              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+              "dependencies": {
+                "block-stream": {
+                  "version": "0.0.8",
+                  "from": "block-stream@*",
+                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                },
+                "fstream": {
+                  "version": "1.0.8",
+                  "from": "fstream@^1.0.2",
+                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "4.1.2",
+                      "from": "graceful-fs@^4.1.2",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "tar-pack": {
+              "version": "2.0.0",
+              "from": "tar-pack@~2.0.0",
+              "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-2.0.0.tgz",
+              "dependencies": {
+                "debug": {
+                  "version": "0.7.4",
+                  "from": "debug@~0.7.2",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                },
+                "fstream": {
+                  "version": "0.1.31",
+                  "from": "fstream@~0.1.22",
+                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "3.0.8",
+                      "from": "graceful-fs@~3.0.2",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "fstream-ignore": {
+                  "version": "0.0.7",
+                  "from": "fstream-ignore@0.0.7",
+                  "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.7.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.2.14",
+                      "from": "minimatch@~0.2.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.7.0",
+                          "from": "lru-cache@2",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "from": "sigmund@~1.0.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "1.2.3",
+                  "from": "graceful-fs@1.2",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                },
+                "once": {
+                  "version": "1.1.1",
+                  "from": "once@~1.1.1",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                },
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@~1.0.2",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    }
+                  }
+                },
+                "rimraf": {
+                  "version": "2.2.8",
+                  "from": "rimraf@~2.2.0",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                },
+                "tar": {
+                  "version": "0.1.20",
+                  "from": "tar@~0.1.17",
+                  "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+                  "dependencies": {
+                    "block-stream": {
+                      "version": "0.0.8",
+                      "from": "block-stream@*",
+                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "uid-number": {
+                  "version": "0.0.3",
+                  "from": "uid-number@0.0.3",
+                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
+                }
+              }
             }
           }
         }
       }
     },
     "sshpk": {
-      "version": "1.7.0",
-      "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.0.tgz",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.0.tgz",
-      "dependencies": {
-        "assert-plus": {
-          "version": "0.2.0",
-          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-        }
-      }
+      "version": "1.7.4",
+      "from": "sshpk@>=1.7.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz"
     },
     "stack-trace": {
       "version": "0.0.9",
-      "from": "stack-trace@0.0.9",
+      "from": "stack-trace@>=0.0.0 <0.1.0",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
     },
     "statuses": {
       "version": "1.2.1",
-      "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
+      "from": "statuses@>=1.2.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
     },
     "stream-combiner": {
       "version": "0.0.4",
-      "from": "stream-combiner@0.0.4",
+      "from": "stream-combiner@>=0.0.4 <0.1.0",
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
     },
     "stream-consume": {
       "version": "0.1.0",
-      "from": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
+      "from": "stream-consume@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
-    },
-    "string-length": {
-      "version": "1.0.1",
-      "from": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz"
     },
     "string_decoder": {
       "version": "0.10.31",
-      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "from": "string_decoder@>=0.10.0 <0.11.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+    },
+    "string-length": {
+      "version": "1.0.1",
+      "from": "string-length@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz"
+    },
+    "string-width": {
+      "version": "1.0.1",
+      "from": "string-width@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz"
     },
     "stringstream": {
       "version": "0.0.5",
-      "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "from": "stringstream@>=0.0.4 <0.1.0",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
     },
     "strip-ansi": {
       "version": "3.0.0",
-      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+      "from": "strip-ansi@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
     },
     "strip-bom": {
       "version": "2.0.0",
-      "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "from": "strip-bom@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
     },
     "strip-indent": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "from": "strip-indent@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
     },
     "strip-json-comments": {
       "version": "1.0.4",
-      "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "from": "strip-json-comments@>=1.0.4 <1.1.0",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
     },
-    "success-symbol": {
-      "version": "0.1.0",
-      "from": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz"
-    },
     "superagent": {
-      "version": "1.3.0",
-      "from": "https://registry.npmjs.org/superagent/-/superagent-1.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-1.3.0.tgz",
+      "version": "1.7.2",
+      "from": "superagent@>=1.7.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-1.7.2.tgz",
       "dependencies": {
-        "qs": {
-          "version": "2.3.3",
-          "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+        "async": {
+          "version": "0.9.2",
+          "from": "async@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         },
-        "mime": {
-          "version": "1.3.4",
-          "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+        "combined-stream": {
+          "version": "0.0.7",
+          "from": "combined-stream@>=0.0.4 <0.1.0",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz"
         },
-        "methods": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz"
-        },
-        "extend": {
-          "version": "1.2.1",
-          "from": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz"
+        "delayed-stream": {
+          "version": "0.0.5",
+          "from": "delayed-stream@0.0.5",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
         },
         "form-data": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+          "from": "form-data@0.2.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz"
+        },
+        "mime-db": {
+          "version": "1.12.0",
+          "from": "mime-db@>=1.12.0 <1.13.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+        },
+        "mime-types": {
+          "version": "2.0.14",
+          "from": "mime-types@>=2.0.3 <2.1.0",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz"
+        },
+        "qs": {
+          "version": "2.3.3",
+          "from": "qs@2.3.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
         },
         "readable-stream": {
           "version": "1.0.27-1",
           "from": "readable-stream@1.0.27-1",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz"
-        },
-        "async": {
-          "version": "0.9.2",
-          "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
-        },
-        "combined-stream": {
-          "version": "0.0.7",
-          "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz"
-        },
-        "delayed-stream": {
-          "version": "0.0.5",
-          "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-        },
-        "mime-types": {
-          "version": "2.0.14",
-          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz"
-        },
-        "mime-db": {
-          "version": "1.12.0",
-          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
         }
       }
     },
     "supports-color": {
       "version": "2.0.0",
-      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "from": "supports-color@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
     },
     "tedious": {
-      "version": "1.13.1",
-      "from": "https://registry.npmjs.org/tedious/-/tedious-1.13.1.tgz",
-      "resolved": "https://registry.npmjs.org/tedious/-/tedious-1.13.1.tgz",
+      "version": "1.13.2",
+      "from": "tedious@>=1.12.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/tedious/-/tedious-1.13.2.tgz",
       "dependencies": {
         "iconv-lite": {
           "version": "0.4.13",
-          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+          "from": "iconv-lite@>=0.4.11 <0.5.0",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
         }
       }
     },
     "text-table": {
       "version": "0.2.0",
-      "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "from": "text-table@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
     },
     "thenify": {
-      "version": "3.1.1",
-      "from": "https://registry.npmjs.org/thenify/-/thenify-3.1.1.tgz",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.1.1.tgz"
+      "version": "3.2.0",
+      "from": "thenify@>=3.1.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.2.0.tgz"
     },
     "thenify-all": {
       "version": "1.6.0",
-      "from": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "from": "thenify-all@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz"
     },
     "through": {
       "version": "2.3.8",
-      "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "from": "through@>=2.3.1 <2.4.0",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "through2": {
       "version": "0.6.5",
-      "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+      "from": "through2@>=0.6.3 <0.7.0",
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
       "dependencies": {
         "readable-stream": {
           "version": "1.0.33",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+          "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
         }
       }
     },
     "tildify": {
       "version": "1.1.2",
-      "from": "https://registry.npmjs.org/tildify/-/tildify-1.1.2.tgz",
+      "from": "tildify@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.1.2.tgz"
+    },
+    "time-stamp": {
+      "version": "1.0.0",
+      "from": "time-stamp@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.0.0.tgz"
     },
     "timed-out": {
       "version": "2.0.0",
-      "from": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
+      "from": "timed-out@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
     },
     "timers-ext": {
       "version": "0.1.0",
-      "from": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
+      "from": "timers-ext@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz"
     },
     "toposort-class": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
+      "from": "toposort-class@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz"
     },
     "touch": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz",
+      "from": "touch@1.0.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz"
     },
     "tough-cookie": {
       "version": "2.2.1",
-      "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
+      "from": "tough-cookie@>=2.2.0 <2.3.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
     },
     "trim-newlines": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "from": "trim-newlines@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
     },
     "tryit": {
       "version": "1.0.2",
-      "from": "https://registry.npmjs.org/tryit/-/tryit-1.0.2.tgz",
+      "from": "tryit@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.2.tgz"
     },
     "tunnel-agent": {
-      "version": "0.4.1",
-      "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+      "version": "0.4.2",
+      "from": "tunnel-agent@>=0.4.1 <0.5.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
     },
     "tv4": {
       "version": "1.2.7",
-      "from": "https://registry.npmjs.org/tv4/-/tv4-1.2.7.tgz",
+      "from": "tv4@>=1.2.7 <2.0.0",
       "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.2.7.tgz"
     },
     "tv4-formats": {
       "version": "1.0.2",
-      "from": "https://registry.npmjs.org/tv4-formats/-/tv4-formats-1.0.2.tgz",
+      "from": "tv4-formats@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/tv4-formats/-/tv4-formats-1.0.2.tgz"
     },
     "tweetnacl": {
-      "version": "0.13.2",
-      "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
+      "version": "0.13.3",
+      "from": "tweetnacl@>=0.13.1 <0.14.0",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
     },
     "type-check": {
-      "version": "0.3.1",
-      "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+      "version": "0.3.2",
+      "from": "type-check@>=0.3.1 <0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
     },
     "type-detect": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "from": "type-detect@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
     },
     "type-is": {
-      "version": "1.6.9",
-      "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.9.tgz",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.9.tgz"
+      "version": "1.6.11",
+      "from": "type-is@>=1.5.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.11.tgz"
     },
     "typedarray": {
       "version": "0.0.6",
-      "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "from": "typedarray@>=0.0.5 <0.1.0",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
     },
     "uc.micro": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.0.tgz",
+      "from": "uc.micro@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.0.tgz"
     },
     "uglify-js": {
       "version": "2.6.1",
-      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
+      "from": "uglify-js@>=2.6.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "from": "async@>=0.2.6 <0.3.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-        },
-        "source-map": {
-          "version": "0.5.3",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
         },
         "camelcase": {
           "version": "1.2.1",
-          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "from": "camelcase@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "from": "cliui@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz"
+        },
+        "source-map": {
+          "version": "0.5.3",
+          "from": "source-map@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "from": "window-size@0.1.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+        },
+        "wordwrap": {
+          "version": "0.0.2",
+          "from": "wordwrap@0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "from": "yargs@>=3.10.0 <3.11.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
         }
       }
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
-      "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
     },
     "umzug": {
-      "version": "1.6.0",
-      "from": "https://registry.npmjs.org/umzug/-/umzug-1.6.0.tgz",
-      "resolved": "https://registry.npmjs.org/umzug/-/umzug-1.6.0.tgz",
+      "version": "1.9.0",
+      "from": "umzug@>=1.6.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/umzug/-/umzug-1.9.0.tgz",
       "dependencies": {
-        "bluebird": {
-          "version": "2.10.2",
-          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+        "lodash": {
+          "version": "4.5.0",
+          "from": "lodash@>=4.3.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.5.0.tgz"
         }
       }
     },
     "undefsafe": {
       "version": "0.0.3",
-      "from": "https://registry.npmjs.org/undefsafe/-/undefsafe-0.0.3.tgz",
+      "from": "undefsafe@0.0.3",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-0.0.3.tgz"
     },
     "underscore": {
       "version": "1.6.0",
-      "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+      "from": "underscore@>=1.6.0 <1.7.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
     },
     "underscore.string": {
       "version": "2.4.0",
-      "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+      "from": "underscore.string@>=2.4.0 <2.5.0",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
     },
     "unique-stream": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
+      "from": "unique-stream@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
     },
     "update-notifier": {
       "version": "0.5.0",
-      "from": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.5.0.tgz",
+      "from": "update-notifier@0.5.0",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.5.0.tgz"
     },
     "user-home": {
       "version": "1.1.1",
-      "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+      "from": "user-home@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
     },
     "util": {
       "version": "0.10.3",
-      "from": "util@0.10.3",
+      "from": "util@>=0.10.3 <1.0.0",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "from": "util-deprecate@>=1.0.1 <1.1.0",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
     },
     "uuid": {
       "version": "2.0.1",
-      "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+      "from": "uuid@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
     },
     "uuid4": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/uuid4/-/uuid4-1.0.0.tgz",
+      "from": "uuid4@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/uuid4/-/uuid4-1.0.0.tgz"
     },
     "v8flags": {
-      "version": "2.0.10",
-      "from": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.10.tgz",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.10.tgz"
+      "version": "2.0.11",
+      "from": "v8flags@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz"
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
-      "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
     },
     "validator": {
-      "version": "4.3.0",
-      "from": "https://registry.npmjs.org/validator/-/validator-4.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-4.3.0.tgz"
+      "version": "4.8.0",
+      "from": "validator@>=4.2.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-4.8.0.tgz"
     },
     "vary": {
       "version": "1.1.0",
-      "from": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
+      "from": "vary@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
     },
     "verror": {
       "version": "1.3.6",
-      "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+      "from": "verror@1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
     },
     "vinyl": {
       "version": "0.5.3",
-      "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+      "from": "vinyl@>=0.5.0 <0.6.0",
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz"
     },
     "vinyl-fs": {
       "version": "0.3.14",
-      "from": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
+      "from": "vinyl-fs@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
       "dependencies": {
+        "clone": {
+          "version": "0.2.0",
+          "from": "clone@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+        },
         "graceful-fs": {
           "version": "3.0.8",
-          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+          "from": "graceful-fs@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
         },
         "strip-bom": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+          "from": "strip-bom@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz"
         },
         "vinyl": {
           "version": "0.4.6",
-          "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "from": "vinyl@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
-        },
-        "clone": {
-          "version": "0.2.0",
-          "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
         }
       }
     },
     "wellknown": {
-      "version": "0.4.0",
-      "from": "https://registry.npmjs.org/wellknown/-/wellknown-0.4.0.tgz",
-      "resolved": "https://registry.npmjs.org/wellknown/-/wellknown-0.4.0.tgz",
+      "version": "0.4.1",
+      "from": "wellknown@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/wellknown/-/wellknown-0.4.1.tgz",
       "dependencies": {
         "minimist": {
           "version": "1.1.3",
-          "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "from": "minimist@>=1.1.2 <1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
         }
       }
     },
     "which": {
-      "version": "1.2.0",
-      "from": "https://registry.npmjs.org/which/-/which-1.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.2.0.tgz"
+      "version": "1.2.4",
+      "from": "which@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz"
     },
     "window-size": {
-      "version": "0.1.0",
-      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+      "version": "0.1.4",
+      "from": "window-size@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
+    },
+    "winston": {
+      "version": "2.1.1",
+      "from": "winston@>=2.1.1 <2.2.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
+      "dependencies": {
+        "async": {
+          "version": "1.0.0",
+          "from": "async@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz"
+        }
+      }
     },
     "wkx": {
-      "version": "0.1.0",
-      "from": "https://registry.npmjs.org/wkx/-/wkx-0.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.1.0.tgz"
+      "version": "0.2.0",
+      "from": "wkx@0.2.0",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.2.0.tgz"
     },
     "wordwrap": {
       "version": "0.0.3",
-      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "from": "wordwrap@>=0.0.2 <0.1.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+    },
+    "wrap-ansi": {
+      "version": "1.0.0",
+      "from": "wrap-ansi@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-1.0.0.tgz"
     },
     "wrappy": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+      "from": "wrappy@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
     },
     "wrench": {
       "version": "1.5.8",
-      "from": "https://registry.npmjs.org/wrench/-/wrench-1.5.8.tgz",
+      "from": "wrench@>=1.5.8 <1.6.0",
       "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.5.8.tgz"
     },
     "write": {
       "version": "0.2.1",
-      "from": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "from": "write@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
     },
     "write-file-atomic": {
-      "version": "1.1.3",
-      "from": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.3.tgz",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.3.tgz"
+      "version": "1.1.4",
+      "from": "write-file-atomic@>=1.1.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz"
     },
     "xdg-basedir": {
       "version": "2.0.0",
-      "from": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
+      "from": "xdg-basedir@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz"
     },
     "xml-escape": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz",
+      "from": "xml-escape@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "from": "xtend@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     },
+    "y18n": {
+      "version": "3.2.0",
+      "from": "y18n@>=3.2.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
+    },
     "yargs": {
-      "version": "1.3.3",
-      "from": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz"
+      "version": "3.32.0",
+      "from": "yargs@>=3.30.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz"
     }
   }
 }


### PR DESCRIPTION
NPM is still installing old versions of five-bells-shared and other dependencies, because there is an outdated `npm-shrinkwrap.json` in the root of the project.