### PR TITLE
Validate transfer schemas

### DIFF
--- a/test/getTransferSpec.js
+++ b/test/getTransferSpec.js
@@ -10,7 +10,14 @@ const appHelper = require('./helpers/app')
 const logHelper = require('five-bells-shared/testHelpers/log')
 const sinon = require('sinon')
 const transferExpiryMonitor = require('../src/services/transferExpiryMonitor')
+const transferValidator = require('../src/services/validator').create('Transfer')
 
+function validateTransfer (res) {
+  const validatorResult = transferValidator(res.body)
+  if (!validatorResult.valid) {
+    throw new Error('Transfer schema validation error: ' + JSON.stringify(_.omit(validatorResult.errors[0], ['stack'])))
+  }
+}
 const START_DATE = 1434412800000 // June 16, 2015 00:00:00 GMT
 
 describe('GET /transfers/:uuid', function () {
@@ -50,6 +57,7 @@ describe('GET /transfers/:uuid', function () {
       .get(transfer.id)
       .expect(200)
       .expect(transfer)
+      .expect(validateTransfer)
       .end()
   })
 
@@ -69,6 +77,7 @@ describe('GET /transfers/:uuid', function () {
       .put(transfer.id)
       .send(transfer)
       .expect(201)
+      .expect(validateTransfer)
       .end()
 
     this.clock.tick(1000)
@@ -86,6 +95,7 @@ describe('GET /transfers/:uuid', function () {
           rejected_at: transfer.expires_at
         }
       }))
+      .expect(validateTransfer)
       .end()
   })
 })

--- a/test/putTransferSpec.js
+++ b/test/putTransferSpec.js
@@ -17,6 +17,22 @@ const logHelper = require('five-bells-shared/testHelpers/log')
 const sinon = require('sinon')
 const notificationWorker = require('../src/services/notificationWorker')
 const accounts = require('./data/accounts')
+const transferValidator = require('../src/services/validator').create('Transfer')
+const accountValidator = require('../src/services/validator').create('Account')
+
+function validateTransfer (res) {
+  const validatorResult = transferValidator(res.body)
+  if (!validatorResult.valid) {
+    throw new Error('Transfer schema validation error: ' + JSON.stringify(_.omit(validatorResult.errors[0], ['stack'])))
+  }
+}
+
+function validateAccount (res) {
+  const validatorResult = accountValidator(res.body)
+  if (!validatorResult.valid) {
+    throw new Error('Account schema validation error: ' + JSON.stringify(_.omit(validatorResult.errors[0], ['stack'])))
+  }
+}
 
 const START_DATE = 1434412800000 // June 16, 2015 00:00:00 GMT
 
@@ -156,6 +172,7 @@ describe('PUT /transfers/:id', function () {
         .put(transfer.id)
         .send(transfer)
         .expect(201)
+        .expect(validateTransfer)
         .end()
 
       this.clock.tick(2000)
@@ -164,6 +181,7 @@ describe('PUT /transfers/:id', function () {
         .put(transfer.id)
         .send(transfer)
         .expect(200)
+        .expect(validateTransfer)
         .end()
     })
 
@@ -185,6 +203,7 @@ describe('PUT /transfers/:id', function () {
           proposed_at: '2015-06-16T00:00:00.000Z'
         }
       }))
+      .expect(validateTransfer)
       .end()
 
     this.clock.tick(2000)
@@ -220,6 +239,7 @@ describe('PUT /transfers/:id', function () {
           proposed_at: '2015-06-16T00:00:00.000Z'
         }
       }))
+      .expect(validateTransfer)
       .end()
 
     this.clock.tick(2000)
@@ -292,6 +312,7 @@ describe('PUT /transfers/:id', function () {
       .auth('alice', 'alice')
       .send(transferNoAuthorization)
       .expect(201)
+      .expect(validateTransfer)
       .end()
 
     /* Disable bobs's account */
@@ -307,6 +328,7 @@ describe('PUT /transfers/:id', function () {
       .auth('alice', 'alice')
       .send(transferNoAuthorization)
       .expect(200)
+      .expect(validateTransfer)
       .end()
 
     yield this.request()
@@ -320,6 +342,7 @@ describe('PUT /transfers/:id', function () {
       is_disabled: true,
       ledger: 'http://localhost'
     })
+    .expect(validateAccount)
     .end()
 
     yield this.request()
@@ -333,6 +356,7 @@ describe('PUT /transfers/:id', function () {
         is_disabled: false,
         ledger: 'http://localhost'
       })
+      .expect(validateAccount)
       .end()
   })
 
@@ -353,6 +377,7 @@ describe('PUT /transfers/:id', function () {
           proposed_at: '2015-06-16T00:00:00.000Z'
         }
       }))
+      .expect(validateTransfer)
       .end()
 
     // Check balances
@@ -375,6 +400,7 @@ describe('PUT /transfers/:id', function () {
           proposed_at: '2015-06-16T00:00:00.000Z'
         }
       }))
+      .expect(validateTransfer)
       .end()
 
     yield this.request()
@@ -389,6 +415,7 @@ describe('PUT /transfers/:id', function () {
           proposed_at: '2015-06-16T00:00:00.000Z'
         }
       }))
+      .expect(validateTransfer)
       .end()
   })
 
@@ -409,6 +436,7 @@ describe('PUT /transfers/:id', function () {
             proposed_at: '2015-06-16T00:00:00.000Z'
           }
         }))
+      .expect(validateTransfer)
       .end()
 
     // Check balances
@@ -437,6 +465,7 @@ describe('PUT /transfers/:id', function () {
           proposed_at: '2015-06-16T00:00:00.000Z'
         }
       }))
+      .expect(validateTransfer)
       .end()
   })
 
@@ -458,6 +487,7 @@ describe('PUT /transfers/:id', function () {
           proposed_at: '2015-06-16T00:00:00.000Z'
         }
       }))
+      .expect(validateTransfer)
       .end()
   })
 
@@ -561,6 +591,7 @@ describe('PUT /transfers/:id', function () {
           proposed_at: '2015-06-16T00:00:00.000Z'
         }
       }))
+      .expect(validateTransfer)
       .end()
 
     // Remove a debit and change credits to match
@@ -594,6 +625,7 @@ describe('PUT /transfers/:id', function () {
             proposed_at: '2015-06-16T00:00:00.000Z'
           }
         }))
+        .expect(validateTransfer)
         .end()
     })
 
@@ -615,6 +647,7 @@ describe('PUT /transfers/:id', function () {
             proposed_at: '2015-06-16T00:00:00.000Z'
           }
         }))
+        .expect(validateTransfer)
         .end()
 
       yield this.request()
@@ -629,6 +662,7 @@ describe('PUT /transfers/:id', function () {
             proposed_at: '2015-06-16T00:00:00.000Z'
           }
         }))
+        .expect(validateTransfer)
         .end()
     })
 
@@ -649,6 +683,7 @@ describe('PUT /transfers/:id', function () {
           proposed_at: '2015-06-16T00:00:00.000Z'
         }
       }))
+      .expect(validateTransfer)
       .end()
   })
 
@@ -668,6 +703,7 @@ describe('PUT /transfers/:id', function () {
           proposed_at: '2015-06-16T00:00:00.000Z'
         }
       }))
+      .expect(validateTransfer)
       .end()
 
     yield this.request()
@@ -698,6 +734,7 @@ describe('PUT /transfers/:id', function () {
             proposed_at: '2015-06-16T00:00:00.000Z'
           }
         }))
+        .expect(validateTransfer)
         .end()
 
       yield this.request()
@@ -713,6 +750,7 @@ describe('PUT /transfers/:id', function () {
             proposed_at: '2015-06-16T00:00:00.000Z'
           }
         }))
+        .expect(validateTransfer)
         .end()
     })
 
@@ -734,6 +772,7 @@ describe('PUT /transfers/:id', function () {
           proposed_at: '2015-06-16T00:00:00.000Z'
         }
       }))
+      .expect(validateTransfer)
       .end()
 
     yield this.request()
@@ -749,6 +788,7 @@ describe('PUT /transfers/:id', function () {
           proposed_at: '2015-06-16T00:00:00.000Z'
         }
       }))
+      .expect(validateTransfer)
       .end()
 
     yield this.request()
@@ -764,6 +804,7 @@ describe('PUT /transfers/:id', function () {
           proposed_at: '2015-06-16T00:00:00.000Z'
         }
       }))
+      .expect(validateTransfer)
       .end()
   })
 
@@ -783,6 +824,7 @@ describe('PUT /transfers/:id', function () {
             proposed_at: '2015-06-16T00:00:00.000Z'
           }
         }))
+        .expect(validateTransfer)
         .end()
     })
 
@@ -803,6 +845,7 @@ describe('PUT /transfers/:id', function () {
           proposed_at: '2015-06-16T00:00:00.000Z'
         }
       }))
+      .expect(validateTransfer)
       .end()
 
     this.clock.tick(1)
@@ -820,6 +863,7 @@ describe('PUT /transfers/:id', function () {
           proposed_at: '2015-06-16T00:00:00.000Z'
         }
       }))
+      .expect(validateTransfer)
       .end()
   })
 
@@ -842,6 +886,7 @@ describe('PUT /transfers/:id', function () {
             proposed_at: '2015-06-16T00:00:00.000Z'
           }
         }))
+        .expect(validateTransfer)
         .end()
 
       yield this.request()
@@ -856,6 +901,7 @@ describe('PUT /transfers/:id', function () {
             proposed_at: '2015-06-16T00:00:00.000Z'
           }
         }))
+        .expect(validateTransfer)
         .end()
     })
 
@@ -884,6 +930,7 @@ describe('PUT /transfers/:id', function () {
           subscription: subscription.id,
           resource: transferResult
         })
+        // TODO validate this against notification schema
         return true
       })
       .reply(204)
@@ -894,6 +941,7 @@ describe('PUT /transfers/:id', function () {
       .send(transfer)
       .expect(201)
       .expect(transferResult)
+      .expect(validateTransfer)
       .end()
 
     yield notificationWorker.processNotificationQueue()
@@ -919,6 +967,7 @@ describe('PUT /transfers/:id', function () {
           proposed_at: '2015-06-16T00:00:00.000Z'
         }
       }))
+      .expect(validateTransfer)
       .end()
 
     yield this.request()
@@ -932,6 +981,7 @@ describe('PUT /transfers/:id', function () {
         balance: '10',
         is_disabled: false
       })
+      .expect(validateAccount)
       .end()
 
     yield this.request()
@@ -945,6 +995,7 @@ describe('PUT /transfers/:id', function () {
         balance: '10',
         is_disabled: false
       })
+      .expect(validateAccount)
       .end()
   })
 
@@ -966,6 +1017,7 @@ describe('PUT /transfers/:id', function () {
           proposed_at: '2015-06-16T00:00:00.000Z'
         }
       }))
+      .expect(validateTransfer)
       .end()
 
     /* prepare */
@@ -982,6 +1034,7 @@ describe('PUT /transfers/:id', function () {
           proposed_at: '2015-06-16T00:00:00.000Z'
         }
       }))
+      .expect(validateTransfer)
       .end()
 
     yield this.request()
@@ -995,6 +1048,7 @@ describe('PUT /transfers/:id', function () {
         balance: '90',
         is_disabled: false
       }))
+      .expect(validateAccount)
       .end()
 
     yield this.request()
@@ -1008,6 +1062,7 @@ describe('PUT /transfers/:id', function () {
         balance: '40',
         is_disabled: false
       }))
+      .expect(validateAccount)
       .end()
   })
 
@@ -1030,6 +1085,7 @@ describe('PUT /transfers/:id', function () {
             proposed_at: '2015-06-16T00:00:00.000Z'
           }
         }))
+        .expect(validateTransfer)
         .end()
 
       /* prepare (authorize) */
@@ -1046,6 +1102,7 @@ describe('PUT /transfers/:id', function () {
             proposed_at: '2015-06-16T00:00:00.000Z'
           }
         }))
+        .expect(validateTransfer)
         .end()
 
       yield this.request()
@@ -1059,6 +1116,7 @@ describe('PUT /transfers/:id', function () {
           balance: '50',
           is_disabled: false
         }))
+        .expect(validateAccount)
         .end()
 
       yield this.request()
@@ -1072,6 +1130,7 @@ describe('PUT /transfers/:id', function () {
           balance: '30',
           is_disabled: false
         }))
+        .expect(validateAccount)
         .end()
 
       yield this.request()
@@ -1085,6 +1144,7 @@ describe('PUT /transfers/:id', function () {
           balance: '30',
           is_disabled: false
         }))
+        .expect(validateAccount)
         .end()
 
       yield this.request()
@@ -1098,6 +1158,7 @@ describe('PUT /transfers/:id', function () {
           balance: '40',
           is_disabled: false
         }))
+        .expect(validateAccount)
         .end()
     })
 
@@ -1121,6 +1182,7 @@ describe('PUT /transfers/:id', function () {
         'signature="' + signature + '"')
       .send(transfer)
       .expect(201)
+      .expect(validateTransfer)
       .end()
   })
 


### PR DESCRIPTION
This should not be merged until #158 is merged. I need to use the newer version of five-bell-shared, so that I can validate the notifications.

There is a lot of duplicated code between the tests. Once I have added schema validation to each test, I'll consolidate, probably by adding a file with some helper methods, so we don't need the validators in each test file. I'm submitting PRs one by one, so they are easier to review.