### PR TITLE
FIX: Floating point precision errors when applying debits/credits

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "bcrypt": "^0.8.5",
+    "bignumber.js": "^2.3.0",
     "canonical-json": "0.0.4",
     "co": "^4.1.0",
     "co-defer": "^1.0.0",

--- a/test/putTransferSpec.js
+++ b/test/putTransferSpec.js
@@ -453,7 +453,10 @@ describe('PUT /transfers/:id', function () {
     expect((yield Account.findByName('bob')).balance).to.equal(10)
   })
 
-  it.skip('should round properly', function * () {
+  // In CI, Oracle is setup with Decimal(10,2) and SQLite doesn't care about precision
+  // So this test will pass for SQLite and fail for Oracle
+  // TODO: Configuration for specifiyng amount precision for the ledger
+  it.skip('should maintain correct precision', function * () {
     const transferWithoutId = _.cloneDeep(this.exampleTransfer)
     delete transferWithoutId.id
     transferWithoutId.debits[0].amount = transferWithoutId.credits[0].amount = '5.0101'


### PR DESCRIPTION
Uses bignumber.js

```js
> 94.9899 - 5.0101
89.97980000000001
```

vs.

```js
> (new Bignumber(94.9899)).minus(5.0101).toNumber()
89.9798
```

Keep numbers as strings