### PR TITLE
Fix overwriting of account settings when not specified in PUT

### DIFF
--- a/src/models/db/account.js
+++ b/src/models/db/account.js
@@ -39,16 +39,20 @@ class Account extends Model {
       delete data.id
     }
 
-    data.balance = Number(data.balance)
-    data.password_hash = data.password ? hashPassword(data.password) : null
-    delete data.password
+    if (data.balance) {
+      data.balance = Number(data.balance)
+    }
+    if (data.password) {
+      data.password_hash = hashPassword(data.password)
+      delete data.password
+    }
 
-    if (!data.minimum_allowed_balance) {
-      data.minimum_allowed_balance = 0
-    } else if (data.minimum_allowed_balance === '-infinity') {
-      data.minimum_allowed_balance = Number.NEGATIVE_INFINITY
-    } else {
-      data.minimum_allowed_balance = Number(data.minimum_allowed_balance)
+    if (data.minimum_allowed_balance) {
+      if (data.minimum_allowed_balance === '-infinity') {
+        data.minimum_allowed_balance = Number.NEGATIVE_INFINITY
+      } else {
+        data.minimum_allowed_balance = Number(data.minimum_allowed_balance)
+      }
     }
 
     return data
@@ -63,8 +67,10 @@ class Account extends Model {
     delete data.fingerprint
     if (data.minimum_allowed_balance === Number.NEGATIVE_INFINITY) {
       data.minimum_allowed_balance = '-infinity'
-    } else {
+    } else if (data.minimum_allowed_balance) {
       data.minimum_allowed_balance = String(Number(data.minimum_allowed_balance))
+    } else {
+      data.minimum_allowed_balance = '0'
     }
     if (!data.connector) delete data.connector
     if (!data.is_admin) delete data.is_admin
@@ -88,8 +94,10 @@ class Account extends Model {
     data.balance = Number(Number(data.balance).toFixed(2))
     if (data.minimum_allowed_balance === null) {
       data.minimum_allowed_balance = Number.NEGATIVE_INFINITY
-    } else {
+    } else if (data.minimum_allowed_balance) {
       data.minimum_allowed_balance = Number(data.minimum_allowed_balance)
+    } else {
+      data.minimum_allowed_balance = 0
     }
     delete data.created_at
     delete data.updated_at
@@ -97,11 +105,15 @@ class Account extends Model {
   }
 
   static convertToPersistent (data) {
-    data.balance = Number(Number(data.balance).toFixed(2))
-    if (data.minimum_allowed_balance === Number.NEGATIVE_INFINITY) {
-      data.minimum_allowed_balance = null
-    } else {
-      data.minimum_allowed_balance = Number(data.minimum_allowed_balance)
+    if (data.balance) {
+      data.balance = Number(Number(data.balance).toFixed(2))
+    }
+    if (data.minimum_allowed_balance) {
+      if (data.minimum_allowed_balance === Number.NEGATIVE_INFINITY) {
+        data.minimum_allowed_balance = null
+      } else {
+        data.minimum_allowed_balance = Number(data.minimum_allowed_balance)
+      }
     }
     return data
   }

--- a/src/models/db/entry.js
+++ b/src/models/db/entry.js
@@ -6,7 +6,9 @@ const knex = require('../../lib/knex').knex
 
 class Entry extends Model {
   static convertFromExternal (data) {
-    data.balance = Number(data.balance)
+    if (data.balance) {
+      data.balance = Number(data.balance)
+    }
     return data
   }
 

--- a/test/accountSpec.js
+++ b/test/accountSpec.js
@@ -380,6 +380,44 @@ describe('Accounts', function () {
         .expect(validator.validateAccount)
         .end()
     })
+
+    it('should allow admin user to disable an account', function * () {
+      const uri = 'http://localhost/accounts/abbey'
+      const account = {
+        name: 'abbey',
+        balance: '50',
+        password: 'password01'
+      }
+      const updatedAccount = {
+        name: account.name,
+        is_disabled: true
+      }
+      const expected = {
+        balance: '50',
+        id: 'http://localhost/accounts/abbey',
+        is_disabled: true,
+        ledger: 'http://localhost',
+        minimum_allowed_balance: '0',
+        name: 'abbey'
+      }
+      yield this.request()  // create "abbey" account
+        .put(uri)
+        .auth('admin', 'admin')
+        .send(account)
+        .expect(201)
+        .end()
+      yield this.request()  // disable "abbey" account
+        .put(uri)
+        .auth('admin', 'admin')
+        .send(updatedAccount)
+        .expect(200)
+        .end()
+      yield this.request()  // check "abbey" account
+        .get(uri)
+        .auth('admin', 'admin')
+        .expect(expected)
+        .end()
+    })
   })
 
   describe('PUT /accounts/:uuid with public_key', function () {

--- a/test/data/transfers/fromZeroMinBalance.json
+++ b/test/data/transfers/fromZeroMinBalance.json
@@ -2,12 +2,12 @@
   "id": "http://localhost/transfers/f1ec03c9-4a81-4f36-bdc8-1e8da056b317",
   "ledger": "http://localhost",
   "debits": [{
-    "account": "http://localhost/accounts/nominbal",
-    "amount": "10",
+    "account": "http://localhost/accounts/alice",
+    "amount": "200",
     "authorized": true
   }],
   "credits": [{
     "account": "http://localhost/accounts/bob",
-    "amount": "10"
+    "amount": "200"
   }]
 }

--- a/test/putTransferSpec.js
+++ b/test/putTransferSpec.js
@@ -1318,7 +1318,7 @@ describe('PUT /transfers/:id', function () {
 
     yield this.request()
       .put(transfer.id)
-      .auth('nominbal', 'nominbal')
+      .auth('alice', 'alice')
       .send(transfer)
       .expect(422)
       .end()


### PR DESCRIPTION
Before this fix, if you PUT an account that just contains a password change it will zero the account's balance.

This was discovered while attempting to solve RILP-354, which was not reproducible.