### PR TITLE
Truncate tables between tests cases. Only migrate once

### DIFF
--- a/test/accountSpec.js
+++ b/test/accountSpec.js
@@ -20,9 +20,13 @@ const START_DATE = 1434412800000 // June 16, 2015 00:00:00 GMT
 describe('Accounts', function () {
   logHelper(logger)
 
+  before(function * () {
+    yield dbHelper.init()
+  })
+
   beforeEach(function * () {
     appHelper.create(this, app)
-    yield dbHelper.init()
+    yield dbHelper.clean()
 
     this.clock = sinon.useFakeTimers(START_DATE, 'Date')
 

--- a/test/fulfillmentSpec.js
+++ b/test/fulfillmentSpec.js
@@ -24,9 +24,13 @@ const START_DATE = 1434412800000 // June 16, 2015 00:00:00 GMT
 describe('GET /fulfillment', function () {
   logHelper(logger)
 
+  before(function * () {
+    yield dbHelper.init()
+  })
+
   beforeEach(function * () {
     appHelper.create(this, app)
-    yield dbHelper.init()
+    yield dbHelper.clean()
     this.clock = sinon.useFakeTimers(START_DATE, 'Date')
 
     this.proposedTransfer = _.cloneDeep(require('./data/transfers/proposed'))
@@ -120,9 +124,13 @@ describe('GET /fulfillment', function () {
 describe('PUT /fulfillment', function () {
   logHelper(logger)
 
+  before(function * () {
+    yield dbHelper.init()
+  })
+
   beforeEach(function * () {
     appHelper.create(this, app)
-    yield dbHelper.init()
+    yield dbHelper.clean()
     this.clock = sinon.useFakeTimers(START_DATE, 'Date')
 
     this.proposedTransfer = _.cloneDeep(require('./data/transfers/proposed'))

--- a/test/getTransferSpec.js
+++ b/test/getTransferSpec.js
@@ -20,9 +20,13 @@ const START_DATE = 1434412800000 // June 16, 2015 00:00:00 GMT
 describe('GET /transfers/:uuid', function () {
   logHelper(logger)
 
+  before(function * () {
+    yield dbHelper.init()
+  })
+
   beforeEach(function * () {
     appHelper.create(this, app)
-    yield dbHelper.init()
+    yield dbHelper.clean()
     this.clock = sinon.useFakeTimers(START_DATE, 'Date')
 
     // Define example data

--- a/test/helpers/db.js
+++ b/test/helpers/db.js
@@ -8,9 +8,37 @@ const Subscription = require('../../src/models/db/subscription').Subscription
 const Notification = require('../../src/models/db/notification').Notification
 const Fulfillment = require('../../src/models/db/conditionFulfillment').ConditionFulfillment
 
+const tables = [
+  'accounts',
+  'fulfillments',
+  'entries',
+  'notifications',
+  'subscriptions',
+  'transfers'
+]
+
+const migrationTables = [
+  'migrations',
+  'migrations_lock'
+]
+
+// Only run migrations once during tests
+let init = false
 exports.init = function * () {
-  yield knex.migrate.rollback(knexConfig).then()
+  if (init) return
+  for (let t of tables.concat(migrationTables)) {
+    yield knex.schema.dropTableIfExists(t).then()
+  }
+
   yield knex.migrate.latest(knexConfig).then()
+  init = true
+  return
+}
+
+exports.clean = function * () {
+  for (let t of tables) {
+    yield knex(t).truncate().then()
+  }
 }
 
 exports.addAccounts = function * (accounts) {

--- a/test/notificationSpec.js
+++ b/test/notificationSpec.js
@@ -16,9 +16,13 @@ const START_DATE = 1434412800000 // June 16, 2015 00:00:00 GMT
 describe('Notifications', function () {
   logHelper(logger)
 
+  before(function * () {
+    yield dbHelper.init()
+  })
+
   beforeEach(function * () {
     appHelper.create(this, app)
-    yield dbHelper.init()
+    yield dbHelper.clean()
     // Define example data
     this.exampleTransfer = _.cloneDeep(require('./data/transfers/simple'))
     this.existingSubscription = _.cloneDeep(require('./data/subscription1'))

--- a/test/putTransferSpec.js
+++ b/test/putTransferSpec.js
@@ -31,9 +31,13 @@ const privateKey = fs.readFileSync('./test/data/private.pem', 'utf8')
 describe('PUT /transfers/:id', function () {
   logHelper(logger)
 
+  before(function * () {
+    yield dbHelper.init()
+  })
+
   beforeEach(function * () {
     appHelper.create(this, app)
-    yield dbHelper.init()
+    yield dbHelper.clean()
 
     this.clock = sinon.useFakeTimers(START_DATE, 'Date')
 

--- a/test/subscriptionSpec.js
+++ b/test/subscriptionSpec.js
@@ -21,9 +21,13 @@ const START_DATE = 1434412800000 // June 16, 2015 00:00:00 GMT
 describe('Subscriptions', function () {
   logHelper(logger)
 
+  before(function * () {
+    yield dbHelper.init()
+  })
+
   beforeEach(function * () {
     appHelper.create(this, app)
-    yield dbHelper.init()
+    yield dbHelper.clean()
     // Define example data
     this.exampleTransfer = _.cloneDeep(require('./data/transfers/simple'))
     this.exampleSubscription = _.cloneDeep(require('./data/subscription1'))

--- a/test/transferStateSpec.js
+++ b/test/transferStateSpec.js
@@ -24,9 +24,13 @@ const START_DATE = 1434412800000 // June 16, 2015 00:00:00 GMT
 describe('Transfer State', function () {
   logHelper(logger)
 
+  before(function * () {
+    yield dbHelper.init()
+  })
+
   beforeEach(function * () {
     appHelper.create(this, app)
-    yield dbHelper.init()
+    yield dbHelper.clean()
     this.clock = sinon.useFakeTimers(START_DATE, 'Date')
 
     this.keyPair =


### PR DESCRIPTION
Should reduce unit test time significantly