### PR TITLE
CI: Fix apidoc upload

### DIFF
--- a/scripts/ci-deploy.sh
+++ b/scripts/ci-deploy.sh
@@ -33,7 +33,8 @@ dockerPush() {
 uploadApiDocs() {
   # On parallel builds, only run apidoc upload on the container that ran the
   # apidoc task
-  if [ -d apidoc-out ]; then
+  if [ ! -d apidoc-out ]; then
+    npm run api-doc
     # Upload API docs to S3
     npm install -g s3-cli
     s3-cli sync --delete-removed apidoc-out s3://interledger-docs/five-bells-ledger/latest/apidoc


### PR DESCRIPTION
The deploy task only runs on container(0) when builds are parallelized.
Artifacts generatd in other containers during test are not available.

CircleCI Support:

> Container 0 is the only one used for deployment, however prior to the
> deployment taking place all of the generated artifacts are already
> uploaded to S3 so if you need to use them you can pull them down or
> reference them from S3.