### PR TITLE
CI: Fix missing docker image on deploy task

### DIFF
--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -103,8 +103,8 @@ threeNodes() {
 
 fourNodes() {
   case "$NODE_INDEX" in
-    0) integrationtest;;
-    1) dockerBuild; sqlitetest; postgrestest;;
+    0) dockerBuild; sqlitetest; postgrestest;;
+    1) integrationtest;;
     2) lint; dockerBuild; mysqltest; apidoc;;
     3) oracletest;;
     *) echo "ERROR: invalid usage"; exit 2;;


### PR DESCRIPTION
Deploy runs on the VM 0 in a parallelized build. If the docker image is
not there, build it first.

See failing build: https://circleci.com/gh/interledger/five-bells-ledger/897