### PR TITLE
Fix debug message

### DIFF
--- a/src/lib/notificationWorker.js
+++ b/src/lib/notificationWorker.js
@@ -131,7 +131,7 @@ class NotificationWorker {
         retry = false
       } else {
         this.log.debug('remote error for notification ' + result.statusCode,
-          result.body)
+          JSON.stringify(result.body))
         this.log.debug(signedNotification)
       }
     } catch (err) {


### PR DESCRIPTION
JSON.stringify the response body

```
 2016-03-28T22:51:50.699Z notificationWorker DEBUG remote error for notification 502 { id: 'ExternalError',
message: 'Remote error: status=400 body=[object Object]' }
```