### PR TITLE
Fix: Config error messaging when missing DB_URI

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -93,7 +93,7 @@ function parseKeysConfig () {
 
 function validateConfig (config) {
   // Validate precision
-  const isOracle = config.getIn(['db', 'uri']).startsWith('oracle://') !== null
+  const isOracle = config.getIn(['db', 'uri'], '').startsWith('oracle://') !== null
   const tlsKey = config.getIn(['tls', 'key'])
   const notificationSigningKey = config.getIn(['keys', 'notification_sign', 'secret'])
 


### PR DESCRIPTION
From this:

```

> five-bells-ledger@11.0.0 start /Users/alan/Projects/five-bells-ledger
> node src/app.js

/Users/alan/Projects/five-bells-ledger/src/lib/config.js:96
  const isOracle = config.getIn(['db', 'uri']).startsWith('oracle://') !== null
                                              ^

TypeError: Cannot read property 'startsWith' of undefined
```

To correct error message:

```
Error: Must set LEDGER_DB_URI or LEDGER_UNIT_DB_URI
    at getKnexConfig (/Users/alan/Projects/five-bells-ledger/src/lib/knex.js:43:11)
```