### PR TITLE
Switch to PBKDF2

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "iojs": ">=1.5"
   },
   "dependencies": {
-    "bcrypt": "^0.8.5",
     "bignumber.js": "^2.3.0",
     "canonical-json": "0.0.4",
     "co": "^4.1.0",
@@ -38,7 +37,7 @@
     "deep-diff": "^0.3.0",
     "eslint-plugin-standard": "^1.3.2",
     "five-bells-condition": "^3.2.0",
-    "five-bells-shared": "^14.1.2",
+    "five-bells-shared": "^16.0.0",
     "keypair": "^1.0.0",
     "knex": "^0.10.0",
     "koa": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "mag-hub": "^0.1.1",
     "methods": "^1.1.1",
     "moment": "^2.10.2",
-    "nodemon": "^1.3.5",
     "passport-anonymous": "^1.0.1",
     "passport-client-certificate": "^0.1.1",
     "passport-http": "^0.3.0",

--- a/scripts/bench_password_hash.js
+++ b/scripts/bench_password_hash.js
@@ -1,0 +1,49 @@
+'use strict'
+
+/**
+ * Benchmark for password hashing with varying number of iterations.
+ *
+ * Useful for deciding the number of iterations, depending on the desired
+ * latency vs security trade-off.
+ *
+ * To use, please run `npm install do-you-even-bench` and then
+ * `node scripts/bench_password_hash.js`.
+ */
+require('do-you-even-bench')([
+  {
+    name: 'pbkdf2-100000',
+    fn: () => {
+      const crypto = require('crypto')
+      crypto.pbkdf2Sync('test', 'test', 100000, 512, 'sha512')
+    }
+  },
+  {
+    name: 'pbkdf2-10000',
+    fn: () => {
+      const crypto = require('crypto')
+      crypto.pbkdf2Sync('test', 'test', 10000, 512, 'sha512')
+    }
+  },
+  {
+    name: 'pbkdf2-1000',
+    fn: () => {
+      const crypto = require('crypto')
+      crypto.pbkdf2Sync('test', 'test', 1000, 512, 'sha512')
+    }
+  },
+  {
+    name: 'pbkdf2-100',
+    fn: () => {
+      const crypto = require('crypto')
+      crypto.pbkdf2Sync('test', 'test', 100, 512, 'sha512')
+    }
+  }
+  // {
+  //   name: 'bcrypt-10',
+  //   fn: () => {
+  //     const bcrypt = require('bcrypt')
+  //     const salt = bcrypt.genSaltSync(10)
+  //     bcrypt.hashSync('test', salt)
+  //   }
+  // }
+])

--- a/src/lib/seed-db.js
+++ b/src/lib/seed-db.js
@@ -20,7 +20,7 @@ function * setupHoldAccount () {
 function * setupAdminAccount (adminParams) {
   const adminAccount = yield models.Account.findByName(adminParams.user)
   const passwordHash =
-    adminParams.pass ? yield hashPassword(adminParams.pass) : undefined
+    adminParams.pass ? (yield hashPassword(adminParams.pass)).toString('base64') : undefined
 
   // Update the password if the account already exists.
   if (adminAccount) {

--- a/src/migrations/201602231400_initial.js
+++ b/src/migrations/201602231400_initial.js
@@ -6,7 +6,7 @@ function createAccountsTable (knex) {
     table.string('name').unique()
     table.decimal('balance', 10, 4)
     table.string('connector', 1024)
-    table.string('password_hash')
+    table.string('password_hash', 1024)
     table.text('public_key')
     table.boolean('is_admin')
     table.boolean('is_disabled')

--- a/src/models/accounts.js
+++ b/src/models/accounts.js
@@ -5,6 +5,7 @@ const config = require('../services/config')
 const log = require('../services/log')('accounts')
 const notificationWorker = require('../services/notificationWorker')
 const db = require('./db/accounts')
+const hashPassword = require('five-bells-shared/utils/hashPassword')
 const NotFoundError = require('five-bells-shared/errors/not-found-error')
 const UnauthorizedError = require('five-bells-shared/errors/unauthorized-error')
 
@@ -42,6 +43,12 @@ function * getAccount (name, requestingUser) {
 
 function * setAccount (account, requestingUser) {
   assert(requestingUser)
+
+  if (account.password) {
+    account.password_hash = (yield hashPassword(account.password)).toString('base64')
+    delete account.password
+  }
+
   const allowedKeys = ['name', 'connector', 'password_hash', 'fingerprint',
     'public_key']
   if (!requestingUser.is_admin && !(requestingUser.name === account.name && (


### PR DESCRIPTION
Requires interledger/five-bells-shared#136

Removes password hashing from five-bells-ledger and uses the facility in five-bells-shared.

Makes password hashing asynchronous. Each password hashing iteration with 10 rounds of bcrypt takes around 60ms in my tests. This is for every request to the ledger and on the main thread. With this patch, the password hashing becomes asynchronous and is removed from the main thread. This reduces the total duration of the unit tests from 35s to about 8s on my machine. The number of "prepare transfer" requests per second increases from 60 req/s to about 110 req/s.

Note that the unit tests were using some rudimentary partial caching for password hashes, so the impact on a live system could be even larger, depending on the number of cores available.

This change does not modify the public API, however it does change the database schema and password hashing and therefore necessitates a database reset.