### PR TITLE
fix: db precision is too low if funding accounts > 1,000,000 balance

### DIFF
--- a/src/migrations/201602231400_initial.js
+++ b/src/migrations/201602231400_initial.js
@@ -4,14 +4,14 @@ function createAccountsTable (knex) {
   return knex.schema.createTableIfNotExists('accounts', (table) => {
     table.increments()
     table.string('name').unique()
-    table.decimal('balance', 10, 4)
+    table.decimal('balance', 20, 4)
     table.string('connector', 1024)
     table.string('password_hash', 1024)
     table.text('public_key')
     table.boolean('is_admin')
     table.boolean('is_disabled')
     table.string('fingerprint').index('fingerprint')
-    table.decimal('minimum_allowed_balance', 10, 4).defaultTo(0)
+    table.decimal('minimum_allowed_balance', 20, 4).defaultTo(0)
   })
 }
 
@@ -30,7 +30,7 @@ function createEntriesTable (knex) {
     // there are cases in which an entry is inserted before the corresponding transfer is inserted
     table.uuid('transfer_id')
     table.integer('account')
-    table.decimal('balance', 10, 4)
+    table.decimal('balance', 20, 4)
     table.timestamp('created_at').defaultTo(knex.fn.now())
   })
 }


### PR DESCRIPTION
This change, 256758d, introduced a change in the scale (digits after
decimal place). To support amounts greater than 1,000,000 (6 digits) we
need more than 10 digits of precision (6 digits before + 4 digits after
decimal point).