### PR TITLE
Update ws dependency to address DoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "koa-passport": "^1.1.6",
     "koa-router": "^5.1.2",
     "koa-static": "^1.4.5",
-    "koa-websocket": "^1.1.0",
+    "koa-websocket": "^2.0.0",
     "lodash": "^3.5.0",
     "mag": "^0.9.1",
     "mag-hub": "^0.1.1",
@@ -88,6 +88,6 @@
     "sinon-chai": "^2.7.0",
     "spec-xunit-file": "0.0.1-3",
     "supertest": "^1.1.0",
-    "ws": "^0.8.0"
+    "ws": "^1.1.0"
   }
 }


### PR DESCRIPTION
ws@v1.0.1 fixed a DoS vulnerability due to buffer allocation https://github.com/websockets/ws/releases/tag/1.0.1