### PR TITLE
fix: use the app's config when creating metadata

### DIFF
--- a/src/controllers/metadata.js
+++ b/src/controllers/metadata.js
@@ -1,26 +1,4 @@
 'use strict'
-const config = require('../services/config')
-
-const base = config.getIn(['server', 'base_uri'])
-const metadata = {
-  currency_code: config.getIn(['currency', 'code']),
-  currency_symbol: config.getIn(['currency', 'symbol']),
-  condition_sign_public_key: config.getIn(['keys', 'ed25519', 'public']),
-  notification_sign_public_key: config.getIn(['keys', 'notification_sign', 'public']),
-  urls: {
-    health: base + '/health',
-    transfer: base + '/transfers/:id',
-    transfer_fulfillment: base + '/transfers/:id/fulfillment',
-    transfer_state: base + '/transfers/:id/state',
-    connectors: base + '/connectors',
-    accounts: base + '/accounts',
-    account: base + '/accounts/:name',
-    subscription: base + '/subscriptions/:id',
-    subscription_notification: base + '/subscriptions/:subscription_id/notifications/:notification_id'
-  },
-  precision: config.get('amount.precision'),
-  scale: config.get('amount.scale')
-}
 
 /**
  * @api {get} / Get the server metadata
@@ -32,4 +10,28 @@ const metadata = {
  *
  * @returns {void}
  */
-exports.getResource = function * () { this.body = metadata }
+module.exports = (config) => ({
+  getResource: function * () {
+    const base = config.getIn(['server', 'base_uri'])
+    const metadata = {
+      currency_code: config.getIn(['currency', 'code']),
+      currency_symbol: config.getIn(['currency', 'symbol']),
+      condition_sign_public_key: config.getIn(['keys', 'ed25519', 'public']),
+      notification_sign_public_key: config.getIn(['keys', 'notification_sign', 'public']),
+      urls: {
+        health: base + '/health',
+        transfer: base + '/transfers/:id',
+        transfer_fulfillment: base + '/transfers/:id/fulfillment',
+        transfer_state: base + '/transfers/:id/state',
+        connectors: base + '/connectors',
+        accounts: base + '/accounts',
+        account: base + '/accounts/:name',
+        subscription: base + '/subscriptions/:id',
+        subscription_notification: base + '/subscriptions/:subscription_id/notifications/:notification_id'
+      },
+      precision: config.get('amount.precision'),
+      scale: config.get('amount.scale')
+    }
+    this.body = metadata
+  }
+})

--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -12,7 +12,7 @@ const path = require('path')
 const logger = require('koa-bunyan-logger')
 const errorHandler = require('five-bells-shared/middlewares/error-handler')
 const UnauthorizedError = require('five-bells-shared/errors/unauthorized-error')
-const metadata = require('../controllers/metadata')
+const getMetadataRoute = require('../controllers/metadata')
 const health = require('../controllers/health')
 const transfers = require('../controllers/transfers')
 const accounts = require('../controllers/accounts')
@@ -27,6 +27,7 @@ class App {
   constructor (modules) {
     this.log = modules.log.create('app')
     this.config = modules.config
+    this.metadata = getMetadataRoute(this.config)
     this.db = modules.db
     this.timerWorker = modules.timerWorker
     this.notificationBroadcaster = modules.notificationBroadcaster
@@ -124,7 +125,7 @@ class App {
 
   _makeRouter () {
     const router = new Router()
-    router.get('/', metadata.getResource)
+    router.get('/', this.metadata.getResource)
     router.get('/health', health.getResource)
 
     router.put('/transfers/:id',


### PR DESCRIPTION
Right now `src/controllers/metadata` includes `src/services/config`. If a different config is passed into the `modules` argument of an App, then the metadata will not match the App's config.